### PR TITLE
feat(manifest): implement accurate cargo breakdown for dashboard

### DIFF
--- a/icd_tz/icd_tz/doctype/manifest/manifest.js
+++ b/icd_tz/icd_tz/doctype/manifest/manifest.js
@@ -4,12 +4,14 @@
 frappe.ui.form.on('Manifest', {
 	refresh: (frm) => {
 		frm.trigger("create_movement_order");
+		frm.trigger("icd_render_manifest_dashboard");
 	},
 	onload: (frm) => {
 		if (!frm.doc.company) {
 			frm.set_value("company", frappe.defaults.get_user_default("Company"));
 		}
 		frm.trigger("create_movement_order");
+		frm.trigger("icd_render_manifest_dashboard");
 	},
 	manifest: (frm) => {
 		if (frm.doc.manifest) {
@@ -37,8 +39,107 @@ frappe.ui.form.on('Manifest', {
 					"received_date": frm.doc.arrival_date,
 					"voyage_no": frm.doc.voyage_no,
 					"company": frm.doc.company,
-				}, doc => {});
+				}, doc => { });
 			}).addClass('btn-primary');
 		}
+	},
+	icd_render_manifest_dashboard: (frm) => {
+		if (!frm.doc.name || frm.doc.containers.length == 0 || frm.doc.docstatus != 1) return;
+
+		frappe.call({
+			method: "get_dashboard_data",
+			doc: frm.doc,
+			callback: function (r) {
+				if (r.message) {
+					const data = r.message;
+
+					const total = data.total_containers;
+					const received = data.received_containers;
+					const pending = data.pending_containers;
+
+					const pct_received = total > 0 ? (received / total) * 100 : 0;
+					const pct_pending = total > 0 ? (pending / total) * 100 : 0;
+
+					let bar_segments = "";
+					if (pct_received > 0) {
+						bar_segments += `
+						<div style="
+							width: ${pct_received}%;
+							background: #2ecc71; /* Green */
+							height: 100%;
+							transition: width 0.3s ease;
+						" title="Received: ${received} of ${total} (${pct_received.toFixed(0)}%)"></div>
+					`;
+					}
+					if (pct_pending > 0) {
+						bar_segments += `
+						<div style="
+							width: ${pct_pending}%;
+							background: #f39c12; /* Orange */
+							height: 100%;
+							transition: width 0.3s ease;
+						" title="Pending: ${pending} of ${total} (${pct_pending.toFixed(0)}%)"></div>
+					`;
+					}
+
+					const kpi_cards = `
+					<div style="flex: 1; min-width: 90px; padding: 10px 14px; border-radius: 8px; background: var(--card-bg); border-left: 3px solid #3498db; text-align: center;">
+						<div style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: #3498db; margin-bottom: 4px;">Total Units</div>
+						<div style="font-size: 20px; font-weight: 700; color: var(--text-color);">${data.total_containers}</div>
+					</div>
+					<div style="flex: 1; min-width: 90px; padding: 10px 14px; border-radius: 8px; background: var(--card-bg); border-left: 3px solid #f39c12; text-align: center;">
+						<div style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: #f39c12; margin-bottom: 4px;">FCL</div>
+						<div style="font-size: 20px; font-weight: 700; color: var(--text-color);">${data.total_fcl}</div>
+					</div>
+					<div style="flex: 1; min-width: 90px; padding: 10px 14px; border-radius: 8px; background: var(--card-bg); border-left: 3px solid #9b59b6; text-align: center;">
+						<div style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: #9b59b6; margin-bottom: 4px;">LCL</div>
+						<div style="font-size: 20px; font-weight: 700; color: var(--text-color);">${data.total_lcl}</div>
+					</div>
+					<div style="flex: 1; min-width: 90px; padding: 10px 14px; border-radius: 8px; background: var(--card-bg); border-left: 3px solid #95a5a6; text-align: center;">
+						<div style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: #95a5a6; margin-bottom: 4px;">Empty</div>
+						<div style="font-size: 20px; font-weight: 700; color: var(--text-color);">${data.total_empty}</div>
+					</div>
+					<div style="flex: 1; min-width: 90px; padding: 10px 14px; border-radius: 8px; background: var(--card-bg); border-left: 3px solid #1abc9c; text-align: center;">
+						<div style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: #1abc9c; margin-bottom: 4px;">Loose</div>
+						<div style="font-size: 20px; font-weight: 700; color: var(--text-color);">${data.total_loose}</div>
+					</div>
+					<div style="flex: 1; min-width: 90px; padding: 10px 14px; border-radius: 8px; background: var(--card-bg); border-left: 3px solid #2ecc71; text-align: center;">
+						<div style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: #2ecc71; margin-bottom: 4px;">Received</div>
+						<div style="font-size: 20px; font-weight: 700; color: var(--text-color);">${data.received_containers}</div>
+					</div>
+					<div style="flex: 1; min-width: 90px; padding: 10px 14px; border-radius: 8px; background: var(--card-bg); border-left: 3px solid #e74c3c; text-align: center;">
+						<div style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: #e74c3c; margin-bottom: 4px;">Pending</div>
+						<div style="font-size: 20px; font-weight: 700; color: var(--text-color);">${data.pending_containers}</div>
+					</div>
+				`;
+
+					const html = `
+					<div class="icd-manifest-dashboard" style="margin-bottom: 16px;">
+						<div style="font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-muted); margin-bottom: 10px;">
+							Container Reception Progress
+						</div>
+
+						<!-- Progress Bar -->
+						<div style="width: 100%; height: 10px; background: var(--border-color); border-radius: 5px; overflow: hidden; display: flex; margin-bottom: 14px;">
+							${bar_segments}
+						</div>
+
+						<!-- KPI Cards -->
+						<div style="display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 10px;">
+							${kpi_cards}
+						</div>
+					</div>
+				`;
+
+					let target = frm.layout.wrapper.find(".form-tabs-list");
+					if (target.length === 0) {
+						target = frm.layout.wrapper.find(".form-section").first();
+					}
+
+					frm.layout.wrapper.find(".icd-manifest-dashboard").remove();
+					target.before(html);
+				}
+			}
+		});
 	}
 });

--- a/icd_tz/icd_tz/doctype/manifest/manifest.py
+++ b/icd_tz/icd_tz/doctype/manifest/manifest.py
@@ -37,15 +37,18 @@ class Manifest(Document):
     def extract_data_from_manifest_file(self):
         if not self.manifest:
             frappe.throw(
-                "<b>Manifest File</b> is missing, Please attach the manifest file before extracting data."
+                frappe._(
+                    "<b>Manifest File</b> is missing, Please attach the manifest file before extracting data."
+                )
             )
 
         # ICD Code validation
         icd_code = frappe.db.get_single_value("ICD TZ Settings", "icd_code")
         if not icd_code:
             frappe.throw(
-                "ICD Code is not configured. Please set it in "
-                "<b>ICD TZ Settings</b> before extracting manifest data."
+                frappe._(
+                    "ICD Code is not configured. Please set it in <b>ICD TZ Settings</b> before extracting manifest data."
+                )
             )
         icd_code = icd_code.strip()
 

--- a/icd_tz/icd_tz/doctype/manifest/manifest.py
+++ b/icd_tz/icd_tz/doctype/manifest/manifest.py
@@ -7,20 +7,21 @@ from openpyxl import load_workbook
 from frappe.model.document import Document
 from frappe.core.doctype.file.utils import delete_file
 
+
 class Manifest(Document):
     def before_save(self):
         if not self.manifest and self.is_new():
             frappe.throw("Please attach the manifest file before saving.")
-        
+
         if not self.is_new() and not self.manifest:
             frappe.throw(
                 "You cannot remove the manifest file once it has been attached.<br>\
                 Please delete the record and create a new one."
             )
-        
+
         if not self.company:
             self.company = frappe.defaults.get_user_default("Company")
-    
+
     def before_submit(self):
         if not self.port:
             frappe.throw("Please fill the <b>Port</b> before submitting.")
@@ -31,12 +32,14 @@ class Manifest(Document):
     def on_trash(self):
         if self.manifest:
             delete_file(self.manifest)
-    
+
     @frappe.whitelist()
     def extract_data_from_manifest_file(self):
         if not self.manifest:
-            frappe.throw("<b>Manifest File</b> is missing, Please attach the manifest file before extracting data.")
-        
+            frappe.throw(
+                "<b>Manifest File</b> is missing, Please attach the manifest file before extracting data."
+            )
+
         # ICD Code validation
         icd_code = frappe.db.get_single_value("ICD TZ Settings", "icd_code")
         if not icd_code:
@@ -47,24 +50,28 @@ class Manifest(Document):
         icd_code = icd_code.strip()
 
         file_url = self.manifest
-        file_path = frappe.get_site_path('private', 'files', file_url.split('/files/')[-1])
-        
+        file_path = frappe.get_site_path(
+            "private", "files", file_url.split("/files/")[-1]
+        )
+
         # Load the Excel file
         workbook = load_workbook(file_path, data_only=True)
 
         # Function to convert dates
         def convert_date(excel_date):
             if isinstance(excel_date, datetime):
-                return excel_date.strftime('%Y-%m-%d')
+                return excel_date.strftime("%Y-%m-%d")
             if isinstance(excel_date, str):
                 try:
-                    return datetime.strptime(excel_date, '%d/%m/%Y').strftime('%Y-%m-%d')
+                    return datetime.strptime(excel_date, "%d/%m/%Y").strftime(
+                        "%Y-%m-%d"
+                    )
                 except ValueError:
                     return None
             return None
 
         # Process the MRN Detail (1) sheet
-        vessel_info_sheet = workbook['MRN Detail (1)']
+        vessel_info_sheet = workbook["MRN Detail (1)"]
         vessel_info_row = next(vessel_info_sheet.iter_rows(min_row=4, values_only=True))
         self.mrn = vessel_info_row[0]
         self.vessel_name = vessel_info_row[1]
@@ -74,7 +81,7 @@ class Manifest(Document):
         self.tpa_uid = vessel_info_row[6]
 
         # Build ICD allowlist from Master BL List (4) first — col[4] is place_of_delivery
-        master_bl_sheet = workbook['Master BL List (4)']
+        master_bl_sheet = workbook["Master BL List (4)"]
         allowed_mbl_nos = self._get_allowed_mbl_nos(master_bl_sheet, icd_code)
         if not allowed_mbl_nos:
             frappe.throw(
@@ -84,23 +91,23 @@ class Manifest(Document):
             )
 
         # Process the Container (2) sheet
-        containers_sheet = workbook['Container (2)']
+        containers_sheet = workbook["Container (2)"]
         self.update_container_details(containers_sheet, allowed_mbl_nos)
 
         # Process the HBL Container (3) sheet
-        hbl_containers_sheet = workbook['HBL Container (3)']
+        hbl_containers_sheet = workbook["HBL Container (3)"]
         self.update_hbl_containers(hbl_containers_sheet, allowed_mbl_nos)
-        
+
         # Process the Master BL List (4) sheet — reuse already-loaded sheet
         self.update_master_bl_details(master_bl_sheet, allowed_mbl_nos)
 
         # Process the House BL List (5) sheet
-        house_bl_sheet = workbook['House BL List (5)']
+        house_bl_sheet = workbook["House BL List (5)"]
         self.update_house_bl_details(house_bl_sheet, allowed_mbl_nos)
-    
+
         # self.save()
         return False
-    
+
     def _get_allowed_mbl_nos(self, master_bl_sheet, icd_code: str) -> set:
         """Return the set of M B/L Nos whose Place of Delivery matches icd_code.
 
@@ -263,30 +270,79 @@ class Manifest(Document):
             house_bl.notify_tin = row[35]
             house_bl.shipping_mark = row[36]
             house_bl.oil_type = row[37]
-    
+
     def create_consignees(self):
         def create_consignee(row):
-            consignee = frappe.get_doc({
-                "doctype": "Consignee",
-                "consignee_name": row.consignee_name,
-                "consignee_tel": row.consignee_tel,
-                "consignee_tin": row.consignee_tin,
-                "consignee_address": row.consignee_address,
-            })
+            consignee = frappe.get_doc(
+                {
+                    "doctype": "Consignee",
+                    "consignee_name": row.consignee_name,
+                    "consignee_tel": row.consignee_tel,
+                    "consignee_tin": row.consignee_tin,
+                    "consignee_address": row.consignee_address,
+                }
+            )
             consignee.insert(ignore_permissions=True)
-        
+
         for row in self.master_bl:
             if not row.consignee_name:
                 continue
 
             if not frappe.db.exists("Consignee", row.consignee_name):
                 create_consignee(row)
-        
+
         for row in self.house_bl:
             if not row.consignee_name:
                 continue
 
             if not frappe.db.exists("Consignee", row.consignee_name):
                 create_consignee(row)
-        
-        
+
+    @frappe.whitelist()
+    def get_dashboard_data(self):
+        total_units = len(self.containers)
+
+        # Identify HBLs to determine LCL
+        hbl_container_nos = set(
+            c.container_no for c in self.hbl_containers if c.container_no
+        )
+
+        total_loose = 0
+        total_empty = 0
+        total_lcl = 0
+        total_fcl = 0
+
+        for c in self.containers:
+            cno = (c.container_no or "").upper()
+
+            # Empty Container
+            if c.freight_indicator == "EMP" or "MTY" in cno or "EMPTY" in cno:
+                total_empty += 1
+            # LCL Container (has House Bills)
+            elif c.container_no in hbl_container_nos:
+                total_lcl += 1
+            # FCL Container (Physical container, not empty, no HBLs)
+            elif c.type_of_container == "C":
+                total_fcl += 1
+            # Loose Cargo / Vehicles / Other
+            else:
+                total_loose += 1
+
+        # Count received physical units/cargo directly from Container Reception
+        received_units = frappe.db.count(
+            "Container Reception", {"manifest": self.name, "docstatus": 1}
+        )
+
+        pending_units = total_units - received_units
+        if pending_units < 0:
+            pending_units = 0
+
+        return {
+            "total_containers": total_units,
+            "total_fcl": total_fcl,
+            "total_lcl": total_lcl,
+            "total_empty": total_empty,
+            "total_loose": total_loose,
+            "received_containers": received_units,
+            "pending_containers": pending_units,
+        }


### PR DESCRIPTION
- Updated get_dashboard_data in manifest.py to classify cargo into FCL, LCL, Empty, and Loose based on HBL presence and indicators.
- Ensured all units (including vehicles) are caught in the breakdown so that the sum perfectly matches Total Units.
- Updated manifest.js to render 7 distinct KPI cards with colors.
- Corrected UI injection to place the dashboard above the tabs list instead of trapping it inside the first tab section.