### PR TITLE
feat(backend): update Transporter links to standard Supplier

### DIFF
--- a/icd_tz/icd_tz/doctype/container_movement_order/container_movement_order.json
+++ b/icd_tz/icd_tz/doctype/container_movement_order/container_movement_order.json
@@ -96,7 +96,7 @@
    "in_preview": 1,
    "in_standard_filter": 1,
    "label": "Transporter",
-   "options": "Transporter",
+   "options": "Supplier",
    "reqd": 1
   },
   {

--- a/icd_tz/icd_tz/doctype/container_reception/container_reception.json
+++ b/icd_tz/icd_tz/doctype/container_reception/container_reception.json
@@ -454,7 +454,7 @@
    "fieldname": "transporter",
    "fieldtype": "Link",
    "label": "Transporter",
-   "options": "Transporter",
+   "options": "Supplier",
    "read_only": 1,
    "search_index": 1
   },

--- a/icd_tz/icd_tz/doctype/transporter/transporter.json
+++ b/icd_tz/icd_tz/doctype/transporter/transporter.json
@@ -162,5 +162,6 @@
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],
- "track_changes": 1
+ "track_changes": 1,
+ "in_create": 1
 }


### PR DESCRIPTION
- Deprecated custom Transporter DocType by preventing manual creation
- Updated link options in Container Movement Order and Container Reception to point to Supplier