### PR TITLE
feat(sales-order): make discount fields read-only when M BL No is set

### DIFF
--- a/icd_tz/patches/property_setters_json/01_icd_on_sales_order.json
+++ b/icd_tz/patches/property_setters_json/01_icd_on_sales_order.json
@@ -15,5 +15,40 @@
         "value": "[\"customer_section\", \"column_break0\", \"title\", \"naming_series\", \"customer\", \"customer_name\", \"tax_id\", \"order_type\", \"column_break_7\", \"transaction_date\", \"posting_date\", \"delivery_date\", \"column_break1\", \"po_no\", \"po_date\", \"company\", \"skip_delivery_note\", \"amended_from\", \"custom_consignee\", \"custom_service_order\", \"custom_container_no\", \"accounting_dimensions_section\", \"cost_center\", \"dimension_col_break\", \"project\", \"currency_and_price_list\", \"currency\", \"conversion_rate\", \"column_break2\", \"selling_price_list\", \"price_list_currency\", \"plc_conversion_rate\", \"ignore_pricing_rule\", \"sec_warehouse\", \"scan_barcode\", \"default_item_discount\", \"column_break_28\", \"set_warehouse\", \"items_section\", \"items\", \"section_break_31\", \"total_qty\", \"total_net_weight\", \"column_break_33\", \"base_total\", \"base_net_total\", \"column_break_33a\", \"total\", \"net_total\", \"taxes_section\", \"tax_category\", \"taxes_and_charges\", \"column_break_38\", \"shipping_rule\", \"column_break_49\", \"incoterm\", \"named_place\", \"section_break_40\", \"taxes\", \"section_break_43\", \"base_total_taxes_and_charges\", \"column_break_46\", \"total_taxes_and_charges\", \"totals\", \"base_grand_total\", \"base_rounding_adjustment\", \"base_rounded_total\", \"base_in_words\", \"column_break3\", \"grand_total\", \"rounding_adjustment\", \"rounded_total\", \"in_words\", \"advance_paid\", \"disable_rounded_total\", \"section_break_48\", \"apply_discount_on\", \"base_discount_amount\", \"coupon_code\", \"column_break_50\", \"additional_discount_percentage\", \"discount_amount\", \"sec_tax_breakup\", \"other_charges_calculation\", \"packing_list\", \"packed_items\", \"pricing_rule_details\", \"pricing_rules\", \"contact_info\", \"billing_address_column\", \"customer_address\", \"address_display\", \"customer_group\", \"territory\", \"column_break_84\", \"contact_person\", \"contact_display\", \"contact_phone\", \"contact_mobile\", \"contact_email\", \"shipping_address_column\", \"shipping_address_name\", \"shipping_address\", \"column_break_93\", \"dispatch_address_name\", \"dispatch_address\", \"col_break46\", \"company_address\", \"column_break_92\", \"company_address_display\", \"payment_schedule_section\", \"payment_terms_section\", \"payment_terms_template\", \"payment_schedule\", \"terms_section_break\", \"tc_name\", \"terms\", \"more_info\", \"section_break_78\", \"status\", \"delivery_status\", \"per_delivered\", \"column_break_81\", \"per_billed\", \"per_picked\", \"billing_status\", \"sales_team_section_break\", \"sales_partner\", \"column_break7\", \"amount_eligible_for_commission\", \"commission_rate\", \"total_commission\", \"section_break1\", \"sales_team\", \"loyalty_points_redemption\", \"loyalty_points\", \"column_break_116\", \"loyalty_amount\", \"subscription_section\", \"from_date\", \"to_date\", \"column_break_108\", \"auto_repeat\", \"update_auto_repeat_reference\", \"printing_details\", \"letter_head\", \"group_same_items\", \"column_break4\", \"select_print_heading\", \"language\", \"additional_info_section\", \"is_internal_customer\", \"represents_company\", \"column_break_152\", \"source\", \"inter_company_order_reference\", \"campaign\", \"party_account_currency\", \"connections_tab\"]",
         "doctype": "Property Setter",
         "__last_sync_on": "2024-09-25T13:57:21.570Z"
+    },
+    {
+        "doc_type": "Sales Order",
+        "field_name": "apply_discount_on",
+        "property": "read_only_depends_on",
+        "property_type": "Code",
+        "value": "eval:doc.m_bl_no"
+    },
+    {
+        "doc_type": "Sales Order",
+        "field_name": "base_discount_amount",
+        "property": "read_only_depends_on",
+        "property_type": "Code",
+        "value": "eval:doc.m_bl_no"
+    },
+    {
+        "doc_type": "Sales Order",
+        "field_name": "coupon_code",
+        "property": "read_only_depends_on",
+        "property_type": "Code",
+        "value": "eval:doc.m_bl_no"
+    },
+    {
+        "doc_type": "Sales Order",
+        "field_name": "additional_discount_percentage",
+        "property": "read_only_depends_on",
+        "property_type": "Code",
+        "value": "eval:doc.m_bl_no"
+    },
+    {
+        "doc_type": "Sales Order",
+        "field_name": "discount_amount",
+        "property": "read_only_depends_on",
+        "property_type": "Code",
+        "value": "eval:doc.m_bl_no"
     }
 ]


### PR DESCRIPTION
Add read_only_depends_on property setters (eval:doc.m_bl_no) on apply_discount_on, base_discount_amount, coupon_code, additional_discount_percentage, and discount_amount.