### PR TITLE
feat(sales-order-item): lock item, pricing and discount fields to M BL No

### DIFF
--- a/icd_tz/patches/property_setters_json/06_icd_on_sales_order_item.json
+++ b/icd_tz/patches/property_setters_json/06_icd_on_sales_order_item.json
@@ -2,22 +2,64 @@
   {
     "doc_type": "Sales Order Item",
     "field_name": "item_code",
-    "property": "read_only",
-    "property_type": "Check",
-    "value": "1"
+    "property": "read_only_depends_on",
+    "property_type": "Code",
+    "value": "eval:parent.m_bl_no"
   },
   {
     "doc_type": "Sales Order Item",
     "field_name": "qty",
-    "property": "read_only",
-    "property_type": "Check",
-    "value": "1"
+    "property": "read_only_depends_on",
+    "property_type": "Code",
+    "value": "eval:parent.m_bl_no"
   },
   {
     "doc_type": "Sales Order Item",
     "field_name": "rate",
-    "property": "read_only",
-    "property_type": "Check",
-    "value": "1"
+    "property": "read_only_depends_on",
+    "property_type": "Code",
+    "value": "eval:parent.m_bl_no"
+  },
+  {
+    "doc_type": "Sales Order Item",
+    "field_name": "discount_percentage",
+    "property": "read_only_depends_on",
+    "property_type": "Code",
+    "value": "eval:parent.m_bl_no"
+  },
+  {
+    "doc_type": "Sales Order Item",
+    "field_name": "discount_amount",
+    "property": "read_only_depends_on",
+    "property_type": "Code",
+    "value": "eval:parent.m_bl_no"
+  },
+  {
+    "doc_type": "Sales Order Item",
+    "field_name": "distributed_discount_amount",
+    "property": "read_only_depends_on",
+    "property_type": "Code",
+    "value": "eval:parent.m_bl_no"
+  },
+  {
+    "doc_type": "Sales Order Item",
+    "field_name": "price_list_rate",
+    "property": "read_only_depends_on",
+    "property_type": "Code",
+    "value": "eval:parent.m_bl_no"
+  },
+  {
+    "doc_type": "Sales Order Item",
+    "field_name": "margin_type",
+    "property": "read_only_depends_on",
+    "property_type": "Code",
+    "value": "eval:parent.m_bl_no"
+  },
+  {
+    "doc_type": "Sales Order Item",
+    "field_name": "margin_rate_or_amount",
+    "property": "read_only_depends_on",
+    "property_type": "Code",
+    "value": "eval:parent.m_bl_no"
   }
 ]


### PR DESCRIPTION
Switch item_code, qty, and rate from a hard read_only to read_only_depends_on (eval:parent.m_bl_no), and extend the same depends-on lock to discount_percentage, discount_amount, distributed_discount_amount, price_list_rate, margin_type, and margin_rate_or_amount.