### PR TITLE
feat(sales-invoice-item): lock discount and margin fields to M BL No

### DIFF
--- a/icd_tz/patches/property_setters_json/07_icd_on_sales_invoice_item.json
+++ b/icd_tz/patches/property_setters_json/07_icd_on_sales_invoice_item.json
@@ -1,0 +1,37 @@
+[
+  {
+    "doc_type": "Sales Invoice Item",
+    "field_name": "discount_percentage",
+    "property": "read_only_depends_on",
+    "property_type": "Code",
+    "value": "eval:parent.m_bl_no"
+  },
+  {
+    "doc_type": "Sales Invoice Item",
+    "field_name": "discount_amount",
+    "property": "read_only_depends_on",
+    "property_type": "Code",
+    "value": "eval:parent.m_bl_no"
+  },
+  {
+    "doc_type": "Sales Invoice Item",
+    "field_name": "distributed_discount_amount",
+    "property": "read_only_depends_on",
+    "property_type": "Code",
+    "value": "eval:parent.m_bl_no"
+  },
+  {
+    "doc_type": "Sales Invoice Item",
+    "field_name": "margin_type",
+    "property": "read_only_depends_on",
+    "property_type": "Code",
+    "value": "eval:parent.m_bl_no"
+  },
+  {
+    "doc_type": "Sales Invoice Item",
+    "field_name": "margin_rate_or_amount",
+    "property": "read_only_depends_on",
+    "property_type": "Code",
+    "value": "eval:parent.m_bl_no"
+  }
+]


### PR DESCRIPTION
New property setters (eval:parent.m_bl_no) making discount_percentage, discount_amount, distributed_discount_amount, margin_type, and margin_rate_or_amount read-only depends on the parent Sales Invoice's M BL No.