### PR TITLE
feat(waiver-request): add Single Item discount and Discount Criteria

### DIFF
--- a/icd_tz/icd_tz/api/sales_order.js
+++ b/icd_tz/icd_tz/api/sales_order.js
@@ -24,5 +24,215 @@ frappe.ui.form.on('Sales Order', {
                 }
             }
         });
+    },
+    request_waiver: (frm) => {
+        if (frm.is_dirty()) {
+            frappe.msgprint("Please save the document before requesting a waiver");
+            return;
+        }
+
+        show_waiver_dialog(frm);
     }
 });
+
+var show_waiver_dialog = (frm) => {
+    let dialog = new frappe.ui.Dialog({
+        title: __("Request Waiver"),
+        fields: [
+            {
+                fieldname: "apply_discount_on",
+                label: __("Apply Discount On"),
+                fieldtype: "Select",
+                options: "\nGrand Total\nNet Total\nSingle Item",
+                reqd: 1
+            },
+            {
+                fieldname: "waiver_cb_1",
+                fieldtype: "Column Break"
+            },
+            {
+                fieldname: "discount_criteria",
+                label: __("Discount Criteria"),
+                fieldtype: "Select",
+                options: "\nWaiver Based on Percentage\nWaiver Based on Actual Amount",
+                reqd: 1
+            },
+            {
+                fieldname: "waiver_cb_2",
+                fieldtype: "Column Break"
+            },
+            {
+                fieldname: "additional_discount_percentage",
+                label: __("Discount (%)"),
+                fieldtype: "Float",
+                depends_on: "eval:doc.discount_criteria == 'Waiver Based on Percentage'"
+            },
+            {
+                fieldname: "discount_amount",
+                label: __("Discount Amount"),
+                fieldtype: "Currency",
+                depends_on: "eval:doc.discount_criteria == 'Waiver Based on Actual Amount'"
+            },
+            {
+                fieldname: "reason_sec",
+                fieldtype: "Section Break"
+            },
+            {
+                fieldname: "waiver_reason",
+                label: __("Waiver Reason"),
+                fieldtype: "Small Text",
+                reqd: 1,
+                description: __("Reason why this Sales Order is requesting a waiver")
+            },
+            {
+                fieldname: "items_sec",
+                fieldtype: "Section Break",
+                label: __("Items"),
+                depends_on: "eval:doc.apply_discount_on == 'Single Item'"
+            },
+            {
+                fieldname: "items",
+                fieldtype: "HTML"
+            }
+        ]
+    });
+
+    let wrapper = dialog.fields_dict.items.$wrapper;
+
+    dialog.fields_dict.apply_discount_on.df.onchange = () => {
+        if (dialog.get_value("apply_discount_on") == "Single Item") {
+            render_waiver_items(frm, dialog, wrapper);
+        } else {
+            wrapper.html("");
+        }
+    };
+    dialog.fields_dict.discount_criteria.df.onchange = () => {
+        if (dialog.get_value("apply_discount_on") == "Single Item") {
+            render_waiver_items(frm, dialog, wrapper);
+        }
+    };
+    dialog.fields_dict.additional_discount_percentage.df.onchange = () => {
+        if (dialog.get_value("apply_discount_on") == "Single Item") {
+            render_waiver_items(frm, dialog, wrapper);
+        }
+    };
+    dialog.fields_dict.discount_amount.df.onchange = () => {
+        if (dialog.get_value("apply_discount_on") == "Single Item") {
+            render_waiver_items(frm, dialog, wrapper);
+        }
+    };
+
+    dialog.set_primary_action(__("Request Waiver"), () => {
+        let data = dialog.get_values();
+        if (!data) {
+            return;
+        }
+
+        let items = null;
+        if (data.apply_discount_on == "Single Item") {
+            items = get_checked_waiver_items(wrapper);
+            if (items.length == 0) {
+                frappe.msgprint(__("Please select at least one Item"));
+                return;
+            }
+        }
+
+        frappe.call({
+            method: "icd_tz.icd_tz.doctype.waiver_request.waiver_request.create_waiver_request",
+            args: {
+                sales_order: frm.doc.name,
+                apply_discount_on: data.apply_discount_on,
+                discount_criteria: data.discount_criteria,
+                waiver_reason: data.waiver_reason,
+                additional_discount_percentage: data.additional_discount_percentage,
+                discount_amount: data.discount_amount,
+                items: items
+            },
+            freeze: true,
+            freeze_message: __("Please wait..."),
+            callback: (r) => {
+                if (r.message) {
+                    dialog.hide();
+                    frappe.show_alert({
+                        message: __("Waiver Request {0} created successfully", [r.message]),
+                        indicator: "green"
+                    });
+                    frm.reload_doc();
+                }
+            }
+        });
+    });
+
+    dialog.show();
+};
+
+var get_waiver_row_discount = (dialog, actual_price) => {
+    if (dialog.get_value("discount_criteria") == "Waiver Based on Percentage") {
+        return (actual_price * (dialog.get_value("additional_discount_percentage") || 0)) / 100;
+    }
+
+    if (dialog.get_value("discount_criteria") == "Waiver Based on Actual Amount") {
+        return dialog.get_value("discount_amount") || 0;
+    }
+
+    return 0;
+};
+
+var render_waiver_items = (frm, dialog, wrapper) => {
+    let html = `<table class="table table-hover" style="width:100%;">
+        <colgroup>
+            <col width="5%">
+            <col width="40%">
+            <col width="18%">
+            <col width="18%">
+            <col width="19%">
+        </colgroup>
+        <tr>
+            <th><input type="checkbox" id="waiver-select-all" /></th>
+            <th style="background-color: #D3D3D3;">Item</th>
+            <th style="background-color: #D3D3D3;">Amount</th>
+            <th style="background-color: #D3D3D3;">Discount</th>
+            <th style="background-color: #D3D3D3;">Amount After Discount</th>
+        </tr>`;
+
+    frm.doc.items.forEach((row) => {
+        let discount_amount = get_waiver_row_discount(dialog, row.amount);
+        let amount_after_discount = row.amount - discount_amount;
+
+        html += `<tr class="waiver-item-row"
+                data-item_code="${row.item_code}"
+                data-item_name="${row.item_name}"
+                data-actual_price="${row.amount}"
+                data-so_detail="${row.name}"
+                data-discount_amount="${discount_amount}"
+                data-amount_after_discount="${amount_after_discount}">
+            <td><input type="checkbox" class="waiver-item-check"/></td>
+            <td>${row.item_code}</td>
+            <td>${format_currency(row.amount)}</td>
+            <td>${format_currency(discount_amount)}</td>
+            <td>${format_currency(amount_after_discount)}</td>
+        </tr>`;
+    });
+    html += `</table>`;
+    wrapper.html(html);
+
+    wrapper.find("#waiver-select-all").on("click", function () {
+        wrapper.find(".waiver-item-check").prop("checked", $(this).is(":checked"));
+    });
+};
+
+var get_checked_waiver_items = (wrapper) => {
+    let items = [];
+    wrapper.find("tr.waiver-item-row:has(.waiver-item-check:checked)").each(function () {
+        let $row = $(this);
+        items.push({
+            item_code: $row.data("item_code"),
+            item_name: $row.data("item_name"),
+            actual_price: $row.data("actual_price"),
+            so_detail: $row.data("so_detail"),
+            discount_amount: $row.data("discount_amount"),
+            amount_after_discount: $row.data("amount_after_discount")
+        });
+    });
+    return items;
+};

--- a/icd_tz/icd_tz/doctype/waiver_request/test_waiver_request.py
+++ b/icd_tz/icd_tz/doctype/waiver_request/test_waiver_request.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from icd_tz.icd_tz.doctype.waiver_request.waiver_request import create_waiver_request
+from icd_tz.icd_tz.doctype.waiver_request.waiver_request import create_waiver_request, get_items
 
 
 class TestWaiverRequest(FrappeTestCase):
@@ -15,7 +15,9 @@ class TestWaiverRequest(FrappeTestCase):
 		frappe.db.rollback()
 
 	def test_creating_waiver_request_marks_sales_order_pending(self):
-		waiver_request = frappe.get_doc(create_and_get_waiver_request(self.sales_order.name))
+		waiver_request = frappe.get_doc(
+			"Waiver Request", create_and_get_waiver_request(self.sales_order.name)
+		)
 
 		self.sales_order.reload()
 		self.assertEqual(self.sales_order.waiver_status, "Pending")
@@ -24,7 +26,7 @@ class TestWaiverRequest(FrappeTestCase):
 
 	def test_approving_waiver_request_applies_discount_on_sales_order(self):
 		waiver_request = frappe.get_doc(
-			create_and_get_waiver_request(self.sales_order.name, discount_amount=50)
+			"Waiver Request", create_and_get_waiver_request(self.sales_order.name, discount_amount=50)
 		)
 		waiver_request.decision = "Approved"
 		waiver_request.submit()
@@ -38,7 +40,7 @@ class TestWaiverRequest(FrappeTestCase):
 
 	def test_rejecting_waiver_request_does_not_apply_discount(self):
 		waiver_request = frappe.get_doc(
-			create_and_get_waiver_request(self.sales_order.name, discount_amount=50)
+			"Waiver Request", create_and_get_waiver_request(self.sales_order.name, discount_amount=50)
 		)
 		waiver_request.decision = "Rejected"
 		waiver_request.submit()
@@ -49,15 +51,49 @@ class TestWaiverRequest(FrappeTestCase):
 		self.sales_order.submit()
 		self.assertEqual(self.sales_order.docstatus, 1)
 
+	def test_approving_single_item_waiver_discounts_only_that_item(self):
+		items = get_items(self.sales_order.name)
+		target = items[0]
+
+		name = create_waiver_request(
+			sales_order=self.sales_order.name,
+			apply_discount_on="Single Item",
+			discount_criteria="Waiver Based on Actual Amount",
+			waiver_reason="Customer requested a waiver on one item",
+			discount_amount=20,
+			items=[
+				{
+					"item_code": target["item_code"],
+					"item_name": target["item_name"],
+					"actual_price": target["actual_price"],
+					"discount_amount": 20,
+					"amount_after_discount": target["actual_price"] - 20,
+					"so_detail": target["so_detail"],
+				}
+			],
+		)
+		waiver_request = frappe.get_doc("Waiver Request", name)
+		self.assertEqual(waiver_request.total_actual_amount, target["actual_price"])
+		self.assertEqual(waiver_request.total_discounted_amount, 20)
+
+		waiver_request.decision = "Approved"
+		waiver_request.submit()
+
+		self.sales_order.reload()
+		item_row = next(row for row in self.sales_order.items if row.name == target["so_detail"])
+		self.assertEqual(item_row.rate, target["actual_price"] - 20)
+		self.assertEqual(item_row.discount_amount, 20)
+		self.assertEqual(self.sales_order.waiver_status, "Approved")
+
 
 def create_and_get_waiver_request(sales_order, discount_amount=0):
-	name = create_waiver_request(
+	return create_waiver_request(
 		sales_order=sales_order,
 		apply_discount_on="Grand Total",
+		discount_criteria="Waiver Based on Actual Amount",
 		waiver_reason="Customer requested a waiver",
 		discount_amount=discount_amount,
 	)
-	return "Waiver Request", name
 
 
 def make_test_sales_order():
@@ -67,8 +103,8 @@ def make_test_sales_order():
 		.insert(ignore_permissions=True)
 		.name
 	)
-	item = frappe.db.get_value("Item", {"is_sales_item": 1}, "name") or frappe.db.get_value(
-		"Item", {}, "name"
+	item = frappe.db.get_value("Item", {"is_sales_item": 1, "disabled": 0}, "name") or frappe.db.get_value(
+		"Item", {"disabled": 0}, "name"
 	)
 
 	sales_order = frappe.get_doc(

--- a/icd_tz/icd_tz/doctype/waiver_request/waiver_request.js
+++ b/icd_tz/icd_tz/doctype/waiver_request/waiver_request.js
@@ -4,4 +4,146 @@ frappe.ui.form.on("Waiver Request", {
       return { filters: { docstatus: 0 } };
     });
   },
+  sales_order: (frm) => {
+    frm.clear_table("items");
+    frm.refresh_field("items");
+  },
+  apply_discount_on: (frm) => {
+    if (frm.doc.apply_discount_on == "Single Item" && frm.doc.sales_order) {
+      frm.clear_table("items");
+      get_items(frm);
+    } else {
+      frm.clear_table("items");
+      frm.refresh_field("items");
+    }
+  },
+  additional_discount_percentage: (frm) => {
+    recalculate_item_discounts(frm);
+  },
+  discount_amount: (frm) => {
+    recalculate_item_discounts(frm);
+  },
+  discount_criteria: (frm) => {
+    recalculate_item_discounts(frm);
+  },
 });
+
+frappe.ui.form.on("Waiver Request Item", {
+  items_add: (frm) => {
+    if (frm.doc.sales_order) {
+      get_items(frm, true);
+    }
+  },
+  item_code: (frm, cdt, cdn) => {
+    let row = frappe.get_doc(cdt, cdn);
+    if (row.item_code && frm.doc.sales_order) {
+      get_item_details(frm, row);
+    }
+  },
+});
+
+var get_items = (frm, reset_options = false) => {
+  frappe
+    .call({
+      method: "icd_tz.icd_tz.doctype.waiver_request.waiver_request.get_items",
+      args: { sales_order: frm.doc.sales_order },
+    })
+    .then((r) => {
+      if (!r.message || r.message.length == 0) {
+        frappe.show_alert({
+          message: __("No items found on the selected Sales Order"),
+          indicator: "red",
+        });
+        return;
+      }
+
+      if (reset_options) {
+        set_item_code_options(frm, r.message);
+        return;
+      }
+
+      r.message.forEach((row) => {
+        add_item_row(frm, row);
+      });
+      frm.refresh_field("items");
+    });
+};
+
+var get_item_details = (frm, row) => {
+  frappe
+    .call({
+      method:
+        "icd_tz.icd_tz.doctype.waiver_request.waiver_request.get_item_details",
+      args: {
+        sales_order: frm.doc.sales_order,
+        item_code: row.item_code,
+      },
+    })
+    .then((r) => {
+      if (!r.message || r.message.length == 0) {
+        return;
+      }
+
+      set_row_amounts(frm, row, r.message[0]);
+      frm.refresh_field("items");
+    });
+};
+
+var add_item_row = (frm, item) => {
+  let row = frm.add_child("items");
+  set_row_amounts(frm, row, item);
+};
+
+var set_row_amounts = (frm, row, item) => {
+  let discount_amount = get_row_discount_amount(frm, item.actual_price);
+  row.item_code = item.item_code;
+  row.item_name = item.item_name;
+  row.actual_price = item.actual_price;
+  row.so_detail = item.so_detail;
+  row.discount_amount = discount_amount;
+  row.amount_after_discount = item.actual_price - discount_amount;
+};
+
+var get_row_discount_amount = (frm, actual_price) => {
+  if (frm.doc.discount_criteria == "Waiver Based on Percentage") {
+    return (actual_price * (frm.doc.additional_discount_percentage || 0)) / 100;
+  }
+
+  if (frm.doc.discount_criteria == "Waiver Based on Actual Amount") {
+    return frm.doc.discount_amount || 0;
+  }
+
+  return 0;
+};
+
+var recalculate_item_discounts = (frm) => {
+  if (frm.doc.apply_discount_on != "Single Item" || !frm.doc.items.length) {
+    return;
+  }
+
+  frm.doc.items.forEach((row) => {
+    row.discount_amount = get_row_discount_amount(frm, row.actual_price);
+    row.amount_after_discount = row.actual_price - row.discount_amount;
+  });
+  frm.refresh_field("items");
+};
+
+var set_item_code_options = (frm, data) => {
+  let options = data.map((row) => row.item_code);
+  const grid = frm.get_field("items").grid;
+
+  grid.visible_columns = undefined;
+  grid.setup_visible_columns();
+  grid.fields_map.item_code.options = options;
+
+  grid.grid_rows.forEach((row) => {
+    row.docfields.forEach((docfield) => {
+      if (docfield.fieldname === "item_code") {
+        docfield.options = options;
+      }
+    });
+  });
+
+  frm.refresh_field("items");
+  grid.refresh();
+};

--- a/icd_tz/icd_tz/doctype/waiver_request/waiver_request.json
+++ b/icd_tz/icd_tz/doctype/waiver_request/waiver_request.json
@@ -20,8 +20,17 @@
   "net_total",
   "column_break_htdb",
   "apply_discount_on",
+  "discount_criteria",
   "additional_discount_percentage",
   "discount_amount",
+  "items_section",
+  "items",
+  "totals_section",
+  "total_actual_amount",
+  "column_break_totals_a",
+  "total_discounted_amount",
+  "column_break_totals_b",
+  "total_amount_after_discount",
   "section_break_ktxz",
   "waiver_reason",
   "column_break_yuju",
@@ -29,10 +38,10 @@
   "rejection_remarks",
   "section_break_users",
   "requested_by",
-  "amended_from",
   "column_break_users",
   "decided_by",
-  "naming_series"
+  "naming_series",
+  "amended_from"
  ],
  "fields": [
   {
@@ -62,6 +71,35 @@
   {
    "fieldname": "column_break_qcyn",
    "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "sales_order.m_bl_no",
+   "fieldname": "m_bl_no",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "M BL No",
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fetch_from": "sales_order.h_bl_no",
+   "fieldname": "h_bl_no",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "H BL No",
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_fokn",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "sales_order.consignee",
+   "fieldname": "consignee",
+   "fieldtype": "Data",
+   "label": "Consignee",
+   "search_index": 1
   },
   {
    "fieldname": "posting_date",
@@ -104,19 +142,83 @@
    "fieldname": "apply_discount_on",
    "fieldtype": "Select",
    "label": "Apply Discount On",
-   "options": "\nGrand Total\nNet Total",
+   "options": "\nGrand Total\nNet Total\nSingle Item",
    "reqd": 1
   },
   {
-   "fieldname": "additional_discount_percentage",
-   "fieldtype": "Float",
-   "label": "Discount (%)"
+   "fieldname": "discount_criteria",
+   "fieldtype": "Select",
+   "label": "Discount Criteria",
+   "options": "\nWaiver Based on Percentage\nWaiver Based on Actual Amount",
+   "reqd": 1
   },
   {
+   "depends_on": "eval:doc.discount_criteria == \"Waiver Based on Percentage\"",
+   "fieldname": "additional_discount_percentage",
+   "fieldtype": "Float",
+   "label": "Discount (%)",
+   "mandatory_depends_on": "eval:doc.discount_criteria == \"Waiver Based on Percentage\""
+  },
+  {
+   "depends_on": "eval:doc.discount_criteria == \"Waiver Based on Actual Amount\"",
    "fieldname": "discount_amount",
    "fieldtype": "Currency",
    "label": "Discount Amount",
+   "mandatory_depends_on": "eval:doc.discount_criteria == \"Waiver Based on Actual Amount\"",
    "options": "currency"
+  },
+  {
+   "depends_on": "eval:doc.apply_discount_on == \"Single Item\"",
+   "fieldname": "items_section",
+   "fieldtype": "Section Break",
+   "label": "Items"
+  },
+  {
+   "fieldname": "items",
+   "fieldtype": "Table",
+   "label": "Items",
+   "mandatory_depends_on": "eval:doc.apply_discount_on == \"Single Item\"",
+   "options": "Waiver Request Item"
+  },
+  {
+   "depends_on": "eval:doc.apply_discount_on == \"Single Item\" && doc.items && doc.items.length",
+   "fieldname": "totals_section",
+   "fieldtype": "Section Break",
+   "label": "Totals"
+  },
+  {
+   "fieldname": "total_actual_amount",
+   "fieldtype": "Currency",
+   "label": "Total Actual Amount",
+   "options": "currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_totals_a",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "total_discounted_amount",
+   "fieldtype": "Currency",
+   "label": "Total Discounted Amount",
+   "options": "currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_totals_b",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "total_amount_after_discount",
+   "fieldtype": "Currency",
+   "label": "Total Amount After Discount",
+   "options": "currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_ktxz",
+   "fieldtype": "Section Break",
+   "label": "Reason"
   },
   {
    "bold": 1,
@@ -125,6 +227,10 @@
    "fieldtype": "Small Text",
    "label": "Waiver Reason",
    "reqd": 1
+  },
+  {
+   "fieldname": "column_break_yuju",
+   "fieldtype": "Column Break"
   },
   {
    "description": "Set to Approved or Rejected before submitting this waiver request",
@@ -176,49 +282,12 @@
    "options": "Waiver Request",
    "print_hide": 1,
    "read_only": 1
-  },
-  {
-   "fetch_from": "sales_order.m_bl_no",
-   "fieldname": "m_bl_no",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "M BL No",
-   "read_only": 1,
-   "search_index": 1
-  },
-  {
-   "fetch_from": "sales_order.h_bl_no",
-   "fieldname": "h_bl_no",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "H BL No",
-   "read_only": 1,
-   "search_index": 1
-  },
-  {
-   "fieldname": "column_break_fokn",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fetch_from": "sales_order.consignee",
-   "fieldname": "consignee",
-   "fieldtype": "Data",
-   "label": "Consignee",
-   "search_index": 1
-  },
-  {
-   "fieldname": "section_break_ktxz",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "column_break_yuju",
-   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-07-31 18:13:11.009106",
+ "modified": "2026-07-31 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Icd Tz",
  "name": "Waiver Request",
@@ -241,7 +310,6 @@
    "write": 1
   }
  ],
- "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/icd_tz/icd_tz/doctype/waiver_request/waiver_request.py
+++ b/icd_tz/icd_tz/doctype/waiver_request/waiver_request.py
@@ -1,6 +1,6 @@
 import frappe
 from frappe.model.document import Document
-from frappe.utils import get_fullname, get_url_to_form, nowdate, nowtime
+from frappe.utils import flt, get_fullname, get_url_to_form, nowdate, nowtime
 
 
 class WaiverRequest(Document):
@@ -11,6 +11,7 @@ class WaiverRequest(Document):
 
 	def validate(self):
 		self.validate_sales_order()
+		self.set_item_totals()
 
 	def validate_sales_order(self):
 		sales_order = frappe.get_cached_doc("Sales Order", self.sales_order)
@@ -21,6 +22,21 @@ class WaiverRequest(Document):
 
 		if self.is_new() and sales_order.waiver_status == "Pending":
 			frappe.throw(f"A Waiver Request is already pending for Sales Order <b>{self.sales_order}</b>")
+
+	def on_trash(self):
+		frappe.db.set_value("Sales Order", self.sales_order, "waiver_status", "")
+
+	def set_item_totals(self):
+		if self.apply_discount_on != "Single Item":
+			return
+
+		self.total_actual_amount = 0
+		self.total_discounted_amount = 0
+		self.total_amount_after_discount = 0
+		for item in self.items:
+			self.total_actual_amount += flt(item.actual_price)
+			self.total_discounted_amount += flt(item.discount_amount)
+			self.total_amount_after_discount += flt(item.amount_after_discount)
 
 	def after_insert(self):
 		frappe.db.set_value("Sales Order", self.sales_order, "waiver_status", "Pending")
@@ -36,14 +52,17 @@ class WaiverRequest(Document):
 		if not self.decision:
 			frappe.throw("Please set a Decision (Approved or Rejected) before submitting this Waiver Request")
 
-		if (
-			self.decision == "Approved"
-			and not self.additional_discount_percentage
-			and not self.discount_amount
-		):
-			frappe.throw("Please set a Discount (%) or Discount Amount before approving this Waiver Request")
+		if self.decision == "Approved":
+			self.validate_approval()
 
 		self.decided_by = get_fullname(frappe.session.user)
+
+	def validate_approval(self):
+		if not self.additional_discount_percentage and not self.discount_amount:
+			frappe.throw("Please set a Discount (%) or Discount Amount before approving this Waiver Request")
+
+		if self.apply_discount_on == "Single Item" and not self.items:
+			frappe.throw("Please add at least one Item before approving this Waiver Request")
 
 	def on_submit(self):
 		if self.decision == "Approved":
@@ -53,9 +72,14 @@ class WaiverRequest(Document):
 
 	def apply_waiver_discount(self):
 		sales_order = frappe.get_doc("Sales Order", self.sales_order)
-		sales_order.apply_discount_on = self.apply_discount_on
-		sales_order.additional_discount_percentage = self.additional_discount_percentage or 0
-		sales_order.discount_amount = self.discount_amount or 0
+
+		if self.apply_discount_on == "Single Item":
+			self.apply_item_discount(sales_order)
+		else:
+			sales_order.apply_discount_on = self.apply_discount_on
+			sales_order.additional_discount_percentage = self.additional_discount_percentage or 0
+			sales_order.discount_amount = self.discount_amount or 0
+
 		sales_order.waiver_status = "Approved"
 		sales_order.save(ignore_permissions=True)
 
@@ -64,6 +88,18 @@ class WaiverRequest(Document):
 			comment_type="Comment",
 			text=f"Waiver Request <a href='{url}'><b>{self.name}</b></a> was approved. Discount applied on this Sales Order.",
 		)
+
+	def apply_item_discount(self, sales_order):
+		for waiver_item in self.items:
+			for row in sales_order.items:
+				if row.name != waiver_item.so_detail:
+					continue
+
+				row.discount_amount = waiver_item.discount_amount
+				row.rate = waiver_item.amount_after_discount
+				if self.discount_criteria == "Waiver Based on Percentage":
+					row.discount_percentage = self.additional_discount_percentage
+				break
 
 	def reject_waiver(self):
 		frappe.db.set_value("Sales Order", self.sales_order, "waiver_status", "Rejected")
@@ -77,14 +113,65 @@ class WaiverRequest(Document):
 
 
 @frappe.whitelist()
+def get_items(sales_order):
+	sales_order_doc = frappe.get_cached_doc("Sales Order", sales_order)
+	return [
+		{
+			"item_code": item.item_code,
+			"item_name": item.item_name,
+			"actual_price": item.amount,
+			"so_detail": item.name,
+		}
+		for item in sales_order_doc.items
+	]
+
+
+@frappe.whitelist()
+def get_item_details(sales_order, item_code):
+	sales_order_doc = frappe.get_cached_doc("Sales Order", sales_order)
+	return [
+		{
+			"item_code": item.item_code,
+			"item_name": item.item_name,
+			"actual_price": item.amount,
+			"so_detail": item.name,
+		}
+		for item in sales_order_doc.items
+		if item.item_code == item_code
+	]
+
+
+@frappe.whitelist()
 def create_waiver_request(
-	sales_order, apply_discount_on, waiver_reason, additional_discount_percentage=0, discount_amount=0
+	sales_order,
+	apply_discount_on,
+	discount_criteria,
+	waiver_reason,
+	additional_discount_percentage=0,
+	discount_amount=0,
+	items=None,
 ):
 	waiver_request = frappe.new_doc("Waiver Request")
 	waiver_request.sales_order = sales_order
 	waiver_request.apply_discount_on = apply_discount_on
+	waiver_request.discount_criteria = discount_criteria
 	waiver_request.additional_discount_percentage = additional_discount_percentage
 	waiver_request.discount_amount = discount_amount
 	waiver_request.waiver_reason = waiver_reason
+
+	if items:
+		for item in frappe.parse_json(items):
+			waiver_request.append(
+				"items",
+				{
+					"item_code": item.get("item_code"),
+					"item_name": item.get("item_name"),
+					"actual_price": item.get("actual_price"),
+					"discount_amount": item.get("discount_amount"),
+					"amount_after_discount": item.get("amount_after_discount"),
+					"so_detail": item.get("so_detail"),
+				},
+			)
+
 	waiver_request.insert()
 	return waiver_request.name

--- a/icd_tz/icd_tz/doctype/waiver_request_item/waiver_request_item.json
+++ b/icd_tz/icd_tz/doctype/waiver_request_item/waiver_request_item.json
@@ -1,0 +1,84 @@
+{
+ "actions": [],
+ "creation": "2026-07-31 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "item_code",
+  "item_name",
+  "column_break_8jrbe",
+  "actual_price",
+  "discount_amount",
+  "amount_after_discount",
+  "references_section",
+  "so_detail"
+ ],
+ "fields": [
+  {
+   "fieldname": "item_code",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Item Code",
+   "reqd": 1
+  },
+  {
+   "fieldname": "item_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Item Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_8jrbe",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "actual_price",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Actual Price",
+   "options": "currency",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "discount_amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Discount Amount",
+   "options": "currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amount_after_discount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Amount After Discount",
+   "options": "currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "references_section",
+   "fieldtype": "Section Break",
+   "label": "References"
+  },
+  {
+   "fieldname": "so_detail",
+   "fieldtype": "Data",
+   "label": "Sales Order Item",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-07-31 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Icd Tz",
+ "name": "Waiver Request Item",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/icd_tz/icd_tz/doctype/waiver_request_item/waiver_request_item.py
+++ b/icd_tz/icd_tz/doctype/waiver_request_item/waiver_request_item.py
@@ -1,0 +1,5 @@
+from frappe.model.document import Document
+
+
+class WaiverRequestItem(Document):
+	pass


### PR DESCRIPTION
Bring Waiver Request to parity with hms_tz's Patient Discount Request: requesting a waiver against one Sales Order item, not just the whole order, and choosing whether the waiver is percentage- or amount-based.

- Add Single Item to Apply Discount On, and a new Discount Criteria field (Waiver Based on Percentage / Waiver Based on Actual Amount) that decides whether additional_discount_percentage or discount_amount is mandatory and used.
- Add a Waiver Request Item child table (item_code, actual_price, discount_amount, amount_after_discount, so_detail) plus total_actual_amount/total_discounted_amount/total_amount_after_discount summary fields, computed in validate().
- On approval, Single Item waivers now update only the matching Sales Order Item rows (matched via so_detail) instead of the order-level discount fields; Grand Total/Net Total behavior is unchanged.
- Add get_items/get_item_details whitelisted helpers so both the Sales Order dialog and the Waiver Request form itself can populate and price the items table from the linked Sales Order.
- Rebuild the Request Waiver dialog on Sales Order with the item checklist/live discount preview, and flesh out the Waiver Request form script (dynamic item_code options, recalculation on discount criteria/percentage/amount change) for full manual-creation parity.
- Clear waiver_status on the Sales Order when its Waiver Request is deleted, so a discarded draft doesn't leave the order stuck Pending.
- Fix create_and_get_waiver_request in the test suite passing a tuple into frappe.get_doc; add discount_criteria to existing test calls and a new test covering the Single Item approval path.