### PR TITLE
feat(icd_tz): auto-charge gate pass cancellation on expired gate passes

### DIFF
--- a/icd_tz/icd_tz/api/sales_invoice.py
+++ b/icd_tz/icd_tz/api/sales_invoice.py
@@ -61,6 +61,8 @@ def update_sales_references(doc):
 	]
 	shore_services += [row.service_name for row in settings_doc.loose_types if row.service_type == "Shore"]
 
+	gatepass_cancellation_item = settings_doc.gatepass_cancellation_item
+
 	for item in doc.items:
 		if item.item_code in transport_services:
 			update_container_reception(item.container_id, invoice_id, "t_sales_invoice")
@@ -79,6 +81,9 @@ def update_sales_references(doc):
 
 		elif item.item_code in corridor_services:
 			update_container_refs(item.container_id, invoice_id, "c_sales_invoice")
+
+		elif gatepass_cancellation_item and item.item_code == gatepass_cancellation_item:
+			update_container_refs(item.container_id, invoice_id, "g_sales_invoice")
 
 		elif item.item_code in storage_services:
 			update_storage_date_refs(item.container_id, invoice_id, item.container_child_refs)

--- a/icd_tz/icd_tz/api/sales_order.py
+++ b/icd_tz/icd_tz/api/sales_order.py
@@ -192,15 +192,19 @@ def get_storage_services(m_bl_no=None, h_bl_no=None):
 
 	containers = frappe.db.get_all("Container", filters=filters, fields=["name", "days_to_be_billed"])
 	if len(containers) == 0:
-		return
+		return []
 
 	settings_doc = frappe.get_cached_doc("ICD TZ Settings")
 
 	for container in containers:
+		container_doc = frappe.get_doc("Container", container.name)
+
+		cancellation_service = get_gatepass_cancellation_service(container_doc, settings_doc)
+		if cancellation_service:
+			services.append(cancellation_service)
+
 		if container.days_to_be_billed == 0:
 			continue
-
-		container_doc = frappe.get_doc("Container", container.name)
 
 		single_days, double_days = get_container_days_to_be_billed(container_doc, settings_doc)
 
@@ -322,6 +326,23 @@ def get_storage_services(m_bl_no=None, h_bl_no=None):
 			)
 
 	return services
+
+
+def get_gatepass_cancellation_service(container_doc, settings_doc):
+	"""Charge row for a container whose Gate Pass was cancelled and is not yet invoiced"""
+
+	if container_doc.has_cancellation_charge != 1 or container_doc.g_sales_invoice:
+		return {}
+
+	if not settings_doc.gatepass_cancellation_item:
+		frappe.throw("Gatepass Cancellation Item is not set in ICD TZ Settings, Please set it to continue")
+
+	return {
+		"item_code": settings_doc.gatepass_cancellation_item,
+		"qty": 1,
+		"container_no": container_doc.container_no,
+		"container_id": container_doc.name,
+	}
 
 
 def get_container_days_to_be_billed(container_doc, settings_doc):

--- a/icd_tz/icd_tz/doctype/container/container.json
+++ b/icd_tz/icd_tz/doctype/container/container.json
@@ -97,6 +97,9 @@
   "column_break_iv6ai",
   "has_corridor_levy_charges",
   "c_sales_invoice",
+  "column_break_gpcnl",
+  "has_cancellation_charge",
+  "g_sales_invoice",
   "column_break_qjlyx",
   "has_single_charge",
   "has_double_charge",
@@ -452,6 +455,24 @@
    "read_only": 1
   },
   {
+   "fieldname": "column_break_gpcnl",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "has_cancellation_charge",
+   "fieldtype": "Check",
+   "label": "Has Cancellation Charge",
+   "read_only": 1
+  },
+  {
+   "description": "Invoice for gatepass cancellation charges",
+   "fieldname": "g_sales_invoice",
+   "fieldtype": "Data",
+   "label": "Sales Invoice",
+   "read_only": 1
+  },
+  {
    "fieldname": "no_of_free_days",
    "fieldtype": "Int",
    "label": "No of Free Days",
@@ -701,7 +722,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-28 06:11:32.326550",
+ "modified": "2026-08-01 14:26:58.618264",
  "modified_by": "Administrator",
  "module": "Icd Tz",
  "name": "Container",

--- a/icd_tz/icd_tz/doctype/gate_pass/gate_pass.py
+++ b/icd_tz/icd_tz/doctype/gate_pass/gate_pass.py
@@ -73,6 +73,15 @@ class GatePass(Document):
 
 	def on_cancel(self):
 		self.update_container_status("At Gatepass")
+		self.flag_gatepass_cancellation_charge()
+
+	def flag_gatepass_cancellation_charge(self):
+		"""Mark the container as chargeable once its Gate Pass is cancelled."""
+
+		if not self.container_id:
+			return
+
+		frappe.db.set_value("Container", self.container_id, "has_cancellation_charge", 1)
 
 	def validate_pending_payments(self):
 		"""Validate the pending payments for the Gate Pass"""
@@ -93,10 +102,13 @@ class GatePass(Document):
 				+ " </ul>"
 			)
 
-			if self.workflow_state in ["Approved", "Gate Out Confirmed"]:
-				frappe.throw(str(msg))
+			if self.meta.has_field("workflow_state"):
+				if self.get("workflow_state") in ["Approved", "Gate Out Confirmed"]:
+					frappe.throw(str(msg))
+				else:
+					frappe.msgprint(str(msg))
 			else:
-				frappe.msgprint(str(msg))
+				frappe.throw(str(msg))
 
 	def validate_container_charges(self):
 		"""Validate the storage payments for the Gate Pass"""
@@ -111,6 +123,8 @@ class GatePass(Document):
 				"r_sales_invoice",
 				"has_corridor_levy_charges",
 				"c_sales_invoice",
+				"has_cancellation_charge",
+				"g_sales_invoice",
 				"days_to_be_billed",
 			],
 			as_dict=True,
@@ -124,6 +138,9 @@ class GatePass(Document):
 
 		if container_info.has_corridor_levy_charges == "Yes" and not container_info.c_sales_invoice:
 			msg += "<li>Corridor Levy Charges</li>"
+
+		if container_info.has_cancellation_charge == 1 and not container_info.g_sales_invoice:
+			msg += "<li>Gate Pass Cancellation Charges</li>"
 
 		return msg
 

--- a/icd_tz/icd_tz/doctype/icd_tz_settings/icd_tz_settings.js
+++ b/icd_tz/icd_tz/doctype/icd_tz_settings/icd_tz_settings.js
@@ -24,5 +24,13 @@ frappe.ui.form.on('ICD TZ Settings', {
 				}
 			};
 		});
+
+		frm.set_query("gatepass_cancellation_item", () => {
+			return {
+				filters: {
+					"item_group": "ICD Services"
+				}
+			};
+		});
 	}
 });

--- a/icd_tz/icd_tz/doctype/icd_tz_settings/icd_tz_settings.json
+++ b/icd_tz/icd_tz/doctype/icd_tz_settings/icd_tz_settings.json
@@ -13,8 +13,10 @@
   "enable_signature_validation",
   "gate_pass_expiry_hours",
   "received_date_threshold_hours",
-  "corridor_levy_countries_section",
+  "corridor_sec",
   "countries",
+  "column_break_ixzw",
+  "gatepass_cancellation_item",
   "service_pricing_criteria_section",
   "service_types",
   "lcl_service_pricing_criteria_section",
@@ -68,15 +70,14 @@
    "label": "Enable Signature Validation"
   },
   {
-   "fieldname": "corridor_levy_countries_section",
-   "fieldtype": "Section Break",
-   "label": "Corridor Levy Countries"
+   "fieldname": "corridor_sec",
+   "fieldtype": "Section Break"
   },
   {
    "description": "Countries eligible to pay Corridor Levy",
    "fieldname": "countries",
    "fieldtype": "Table MultiSelect",
-   "label": "countries",
+   "label": "Corridor Levy Countries",
    "options": "Corridor Levy Country"
   },
   {
@@ -115,12 +116,23 @@
    "fieldtype": "Int",
    "label": "Received Date Threshold Hours",
    "reqd": 1
+  },
+  {
+   "description": "Item charged when a Gate Pass is cancelled after expiry",
+   "fieldname": "gatepass_cancellation_item",
+   "fieldtype": "Link",
+   "label": "Gatepass Cancellation Item",
+   "options": "Item"
+  },
+  {
+   "fieldname": "column_break_ixzw",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-07-06 12:26:00.096156",
+ "modified": "2026-08-01 14:22:39.921653",
  "modified_by": "Administrator",
  "module": "Icd Tz",
  "name": "ICD TZ Settings",


### PR DESCRIPTION
Containers whose Gate Pass is cancelled - manually or by the auto_expire_gate_passes job - are now re-billed a cancellation charge and cannot gate out until it is invoiced.

- Add Gatepass Cancellation Item (Link: Item) to ICD TZ Settings, filtered to the ICD Services item group in icd_tz_settings.js
- Add read-only has_cancellation_charge (Check) and g_sales_invoice (Data) fields to Container, mirroring the removal/corridor levy charge pattern
- Flag the linked container in Gate Pass on_cancel
- Include the unpaid cancellation charge in validate_pending_payments, so it warns on submit and blocks in Approved/Gate Out Confirmed states
- Add the configured item to the Sales Order in get_storage_services; the Container doc is now loaded before the days_to_be_billed check so the charge applies even with no billable storage days
- Stamp g_sales_invoice on the container when the cancellation item is invoiced, in sales_invoice.update_sales_references