### PR TITLE
feat(icd_tz): prevent duplicate bookings and inspections per container

### DIFF
--- a/icd_tz/icd_tz/doctype/container_inspection/container_inspection.js
+++ b/icd_tz/icd_tz/doctype/container_inspection/container_inspection.js
@@ -5,10 +5,12 @@ frappe.ui.form.on('Container Inspection', {
 	refresh: (frm) =>{
 		frm.trigger("set_filters");
 		frm.trigger("create_service_order");
+		frm.trigger("create_additional_booking");
 	},
 	onload: (frm) => {
 		frm.trigger("set_filters");
 		frm.trigger("create_service_order");
+		frm.trigger("create_additional_booking");
 	},
 	set_filters: (frm) => {
 		frm.set_query("service", "services", () => {
@@ -55,6 +57,69 @@ frappe.ui.form.on('Container Inspection', {
 				}
 			});
 		}
+	},
+	create_additional_booking: (frm) => {
+		if (frm.doc.docstatus != 1) {
+			return;
+		}
+
+		frm.add_custom_button(__('Create Additional Booking'), () => {
+			const bl_no = frm.doc.h_bl_no
+				? __("H BL No: <b>{0}</b>", [frm.doc.h_bl_no])
+				: __("M BL No: <b>{0}</b>", [frm.doc.m_bl_no]);
+
+			frappe.prompt(
+				[
+					{
+						label: __('Expected Inspection Date'),
+						fieldname: 'inspection_date',
+						fieldtype: 'Date',
+						reqd: 1,
+					},
+					{
+						fieldtype: 'Column Break'
+					},
+					{
+						label: __('Expected Inspection Location'),
+						fieldname: 'inspection_location',
+						fieldtype: 'Link',
+						options: 'Container Location',
+						reqd: 1
+					},
+					{
+						fieldtype: "Section Break"
+					},
+					{
+						fieldname: 'confirmation',
+						fieldtype: 'HTML',
+						options: __("Container <b>{0}</b>, {1},   already has a Booking.<br><br> <p style='color: red'><i>Are you sure, you want to create an additional Booking for this container..??</i></p>", [frm.doc.container_no, bl_no])
+					},
+				],
+				(values) => {
+					frappe.call({
+						method: "icd_tz.icd_tz.doctype.in_yard_container_booking.in_yard_container_booking.create_additional_booking",
+						args: {
+							container_inspection: frm.doc.name,
+							inspection_date: values.inspection_date,
+							inspection_location: values.inspection_location
+						},
+						freeze: true,
+						freeze_message: __('<i class="fa fa-spinner fa-spin fa-4x"></i>'),
+						callback: (r) => {
+							if (r.message) {
+								frappe.show_alert({
+									message: __("Additional Booking {0} created successfully", [r.message]),
+									indicator: 'green'
+								}, 10);
+								frappe.set_route("Form", "In Yard Container Booking", r.message);
+							}
+						}
+					});
+				},
+				__('Create Additional Booking'),
+				__('Create Booking'),
+			);
+		});
 	},
 	create_service_order: (frm) => {
 		if (!frm.doc.service_order & frm.doc.docstatus == 1) {

--- a/icd_tz/icd_tz/doctype/container_inspection/container_inspection.json
+++ b/icd_tz/icd_tz/doctype/container_inspection/container_inspection.json
@@ -32,6 +32,7 @@
   "inspection_comments",
   "post_inspection_location",
   "new_container_location",
+  "is_additional_inspection",
   "column_break_gdea",
   "additional_note",
   "services_tab",
@@ -224,6 +225,14 @@
    "search_index": 1
   },
   {
+   "default": "0",
+   "description": "Set when this inspection comes from an additional Booking",
+   "fieldname": "is_additional_inspection",
+   "fieldtype": "Check",
+   "label": "Is Additional Inspection",
+   "read_only": 1
+  },
+  {
    "fetch_from": "container_id.original_location",
    "fieldname": "current_container_location",
    "fieldtype": "Link",
@@ -262,7 +271,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-19 01:29:31.280659",
+ "modified": "2026-08-03 16:00:08.108628",
  "modified_by": "Administrator",
  "module": "Icd Tz",
  "name": "Container Inspection",
@@ -283,6 +292,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/icd_tz/icd_tz/doctype/container_inspection/container_inspection.py
+++ b/icd_tz/icd_tz/doctype/container_inspection/container_inspection.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import nowdate
+from frappe.utils import get_url_to_form, nowdate
 
 from icd_tz.icd_tz.api.utils import validate_cf_agent, validate_draft_doc
 
@@ -23,6 +23,50 @@ class ContainerInspection(Document):
 	def validate(self):
 		validate_draft_doc("In Yard Container Booking", self.in_yard_container_booking)
 		validate_cf_agent(self)
+		self.set_additional_inspection()
+		self.validate_duplicate_inspection()
+
+	def set_additional_inspection(self):
+		"""An inspection raised from an additional booking is itself an additional inspection"""
+
+		if not self.in_yard_container_booking:
+			return
+
+		booking = frappe.db.get_value(
+			"In Yard Container Booking",
+			self.in_yard_container_booking,
+			["container_id", "is_additional_booking"],
+			as_dict=True,
+		)
+
+		self.is_additional_inspection = booking.is_additional_booking
+		if not self.container_id:
+			self.container_id = booking.container_id
+
+	def validate_duplicate_inspection(self):
+		"""Allow one inspection per container, a repeat one must come from an additional booking"""
+
+		if self.is_additional_inspection == 1:
+			return
+
+		existing_inspections = frappe.db.get_all(
+			"Container Inspection",
+			filters={
+				"container_id": self.container_id,
+				"docstatus": ["!=", 2],
+				"name": ["!=", self.name],
+			},
+			pluck="name",
+		)
+		if len(existing_inspections) == 0:
+			return
+
+		url = get_url_to_form("Container Inspection", existing_inspections[0])
+		frappe.throw(
+			f"Inspection <a href='{url}'><b>{existing_inspections[0]}</b></a> already exists for Container: "
+			f"<b>{self.container_no}</b>.<br>If another inspection is needed, create an additional Booking "
+			"from that Container Inspection record first."
+		)
 
 	def on_submit(self):
 		self.update_container_doc()
@@ -120,7 +164,15 @@ def create_bulk_inspections(data):
 		filters["h_bl_no"] = data.get("h_bl_no")
 
 	bookings = frappe.db.get_all(
-		"In Yard Container Booking", filters=filters, fields=["name", "container_id", "inspection_date"]
+		"In Yard Container Booking",
+		filters=filters,
+		fields=[
+			"name",
+			"container_id",
+			"inspection_date",
+			"container_inspection",
+			"is_additional_booking",
+		],
 	)
 	if len(bookings) == 0:
 		msg = ""
@@ -132,8 +184,28 @@ def create_bulk_inspections(data):
 		frappe.msgprint(f"No submitted Container Bookings found for {msg}")
 		return
 
+	inspected_containers = frappe.db.get_all(
+		"Container Inspection",
+		filters={
+			"container_id": ["in", [booking.container_id for booking in bookings]],
+			"docstatus": ["!=", 2],
+		},
+		fields=["container_id"],
+		pluck="container_id",
+	)
+
 	count = 0
+	skipped = 0
 	for booking in bookings:
+		if booking.container_inspection:
+			skipped += 1
+			continue
+
+		# an additional booking always needs its own inspection
+		if booking.is_additional_booking != 1 and booking.container_id in inspected_containers:
+			skipped += 1
+			continue
+
 		doc = frappe.new_doc("Container Inspection")
 		doc.in_yard_container_booking = booking.name
 		doc.container_id = booking.container_id
@@ -146,5 +218,11 @@ def create_bulk_inspections(data):
 
 		if doc.get("name"):
 			count += 1
+
+	if skipped > 0:
+		frappe.msgprint(
+			f"Skipped <b>{skipped}</b> of <b>{len(bookings)}</b> Booking(s), "
+			"they already have an Inspection"
+		)
 
 	return count

--- a/icd_tz/icd_tz/doctype/container_inspection/container_inspection_list.js
+++ b/icd_tz/icd_tz/doctype/container_inspection/container_inspection_list.js
@@ -107,8 +107,8 @@ var show_dialog = (listview) => {
                                 message: __("{0} Inspections Created successfully", [r.message]),
                                 indicator: 'green'
                             }, 10);
-                            listview.refresh();
                         }
+                        listview.refresh();
                     }
                 });
             }

--- a/icd_tz/icd_tz/doctype/in_yard_container_booking/in_yard_container_booking.json
+++ b/icd_tz/icd_tz/doctype/in_yard_container_booking/in_yard_container_booking.json
@@ -44,7 +44,10 @@
   "column_break_unre",
   "container_inspection",
   "naming_series",
-  "amended_from"
+  "amended_from",
+  "column_break_hopp",
+  "is_additional_booking",
+  "source_container_inspection"
  ],
  "fields": [
   {
@@ -273,6 +276,21 @@
    "search_index": 1
   },
   {
+   "default": "0",
+   "description": "Set when this booking is raised from a Container Inspection because the first inspection was not satisfactory",
+   "fieldname": "is_additional_booking",
+   "fieldtype": "Check",
+   "label": "Is Additional Booking",
+   "read_only": 1
+  },
+  {
+   "depends_on": "is_additional_booking",
+   "fieldname": "source_container_inspection",
+   "fieldtype": "Data",
+   "label": "Source Container Inspection",
+   "read_only": 1
+  },
+  {
    "fetch_from": "container_id.m_bl_no",
    "fieldname": "m_bl_no",
    "fieldtype": "Data",
@@ -313,12 +331,16 @@
    "label": "H BL No",
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "column_break_hopp",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-19 00:40:16.361549",
+ "modified": "2026-08-03 15:51:42.128059",
  "modified_by": "Administrator",
  "module": "Icd Tz",
  "name": "In Yard Container Booking",
@@ -338,6 +360,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/icd_tz/icd_tz/doctype/in_yard_container_booking/in_yard_container_booking.py
+++ b/icd_tz/icd_tz/doctype/in_yard_container_booking/in_yard_container_booking.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import now_datetime, nowdate
+from frappe.utils import get_url_to_form, now_datetime, nowdate
 
 
 class InYardContainerBooking(Document):
@@ -19,6 +19,32 @@ class InYardContainerBooking(Document):
 
 	def validate(self):
 		validate_cf_agent(self.c_and_f_company, self.clearing_agent)
+		self.validate_duplicate_booking()
+
+	def validate_duplicate_booking(self):
+		"""Allow one booking per container, a repeat one must come from a Container Inspection"""
+
+		if self.is_additional_booking == 1:
+			return
+
+		existing_bookings = frappe.db.get_all(
+			"In Yard Container Booking",
+			filters={
+				"container_id": self.container_id,
+				"docstatus": ["!=", 2],
+				"name": ["!=", self.name],
+			},
+			pluck="name",
+		)
+		if len(existing_bookings) == 0:
+			return
+
+		url = get_url_to_form("In Yard Container Booking", existing_bookings[0])
+		frappe.throw(
+			f"Booking <a href='{url}'><b>{existing_bookings[0]}</b></a> already exists for Container: "
+			f"<b>{self.container_no}</b>.<br>If another booking is needed, create it from the Container "
+			"Inspection record of this container."
+		)
 
 	def before_submit(self):
 		self.posting_datetime = now_datetime()
@@ -64,8 +90,19 @@ def create_bulk_bookings(data):
 		frappe.msgprint(f"No Containers found for {msg}")
 		return
 
+	booked_containers = frappe.db.get_all(
+		"In Yard Container Booking",
+		filters={"container_id": ["in", containers], "docstatus": ["!=", 2]},
+		pluck="container_id",
+	)
+
 	count = 0
+	skipped = 0
 	for container_id in containers:
+		if container_id in booked_containers:
+			skipped += 1
+			continue
+
 		doc = frappe.new_doc("In Yard Container Booking")
 		doc.c_and_f_company = data.get("c_and_f_company")
 		doc.clearing_agent = data.get("clearing_agent")
@@ -82,4 +119,44 @@ def create_bulk_bookings(data):
 		if doc.get("name"):
 			count += 1
 
+	if skipped > 0:
+		frappe.msgprint(
+			f"Skipped <b>{skipped}</b> of <b>{len(containers)}</b> container(s) for {msg}, "
+			"they already have a Booking"
+		)
+
 	return count
+
+
+@frappe.whitelist()
+def create_additional_booking(container_inspection, inspection_date, inspection_location):
+	"""Create a repeat booking for a container whose inspection was not satisfactory"""
+
+	inspection = frappe.get_cached_doc("Container Inspection", container_inspection)
+	source_booking = frappe.get_cached_doc("In Yard Container Booking", inspection.in_yard_container_booking)
+
+	doc = frappe.new_doc("In Yard Container Booking")
+	doc.update(
+		{
+			"c_and_f_company": source_booking.c_and_f_company,
+			"clearing_agent": source_booking.clearing_agent,
+			"consignee": source_booking.consignee,
+			"container_id": source_booking.container_id,
+			"m_bl_no": source_booking.m_bl_no,
+			"h_bl_no": source_booking.h_bl_no,
+			"inspection_date": inspection_date,
+			"inspection_location": inspection_location,
+			"is_additional_booking": 1,
+			"source_container_inspection": inspection.name,
+		}
+	)
+
+	doc.flags.ignore_permissions = True
+	doc.insert()
+
+	doc.add_comment(
+		"Comment",
+		f"Additional booking created from Container Inspection: <b>{inspection.name}</b>",
+	)
+
+	return doc.name

--- a/icd_tz/icd_tz/doctype/in_yard_container_booking/in_yard_container_booking_list.js
+++ b/icd_tz/icd_tz/doctype/in_yard_container_booking/in_yard_container_booking_list.js
@@ -159,8 +159,8 @@ var show_dialog = (listview) => {
                                 message: __("{0} Bookings Created successfully", [r.message]),
                                 indicator: 'green'
                             }, 10);
-                            listview.refresh();
                         }
+                        listview.refresh();
                     }
                 });
             }


### PR DESCRIPTION
Bulk creation of In Yard Container Bookings and Container Inspections now skips containers that already have one, and reports how many were skipped. A duplicate guard on both doctypes blocks a second record for the same container from any creation path.

When a party is not satisfied with an inspection, a repeat booking is created from the Container Inspection through a new Create Additional Booking button, which prompts for the expected inspection date and location. Such a booking is flagged is_additional_booking and bypasses the guard, and the inspection raised from it inherits the flag as is_additional_inspection so the repeat inspection is allowed too.