### PR TITLE
feat(icd_tz): block records for containers that have left the ICD

### DIFF
--- a/icd_tz/icd_tz/api/utils.py
+++ b/icd_tz/icd_tz/api/utils.py
@@ -1,6 +1,38 @@
 import frappe
 from frappe.utils import cint, nowdate
 
+# Containers on these statuses are leaving or have left the ICD
+DELIVERED_CONTAINER_STATUSES = ["At Gate Confirmation", "Delivered"]
+
+
+def validate_delivered_container(container_id, container_no=None, action="created"):
+	"""Block records that would change a container which has already moved out of the ICD"""
+
+	if not container_id:
+		return
+
+	status = frappe.db.get_value("Container", container_id, "status")
+	if status not in DELIVERED_CONTAINER_STATUSES:
+		return
+
+	frappe.throw(
+		f"Container: <b>{container_no or container_id}</b> is on <b>{status}</b> status, "
+		f"this record cannot be {action}."
+	)
+
+
+def get_delivered_containers(container_ids):
+	"""Containers that have moved out of the ICD, they must be left out of bulk creation"""
+
+	if len(container_ids) == 0:
+		return []
+
+	return frappe.db.get_all(
+		"Container",
+		filters={"name": ["in", container_ids], "status": ["in", DELIVERED_CONTAINER_STATUSES]},
+		pluck="name",
+	)
+
 
 def validate_cf_agent(doc):
 	"""

--- a/icd_tz/icd_tz/doctype/container_inspection/container_inspection.py
+++ b/icd_tz/icd_tz/doctype/container_inspection/container_inspection.py
@@ -5,12 +5,20 @@ import frappe
 from frappe.model.document import Document
 from frappe.utils import get_url_to_form, nowdate
 
-from icd_tz.icd_tz.api.utils import validate_cf_agent, validate_draft_doc
+from icd_tz.icd_tz.api.utils import (
+	get_delivered_containers,
+	validate_cf_agent,
+	validate_delivered_container,
+	validate_draft_doc,
+)
 
 
 class ContainerInspection(Document):
 	def before_insert(self):
 		self.get_custom_verification_services()
+
+	def before_cancel(self):
+		validate_delivered_container(self.container_id, self.container_no, action="cancelled")
 
 	def after_insert(self):
 		self.update_in_yard_booking(value=self.name)
@@ -24,6 +32,11 @@ class ContainerInspection(Document):
 		validate_draft_doc("In Yard Container Booking", self.in_yard_container_booking)
 		validate_cf_agent(self)
 		self.set_additional_inspection()
+
+		# container_id is fetched from the booking, so check only after it is resolved
+		if self.is_new():
+			validate_delivered_container(self.container_id, self.container_no)
+
 		self.validate_duplicate_inspection()
 
 	def set_additional_inspection(self):
@@ -184,19 +197,24 @@ def create_bulk_inspections(data):
 		frappe.msgprint(f"No submitted Container Bookings found for {msg}")
 		return
 
-	inspected_containers = frappe.db.get_all(
-		"Container Inspection",
-		filters={
-			"container_id": ["in", [booking.container_id for booking in bookings]],
-			"docstatus": ["!=", 2],
-		},
-		fields=["container_id"],
-		pluck="container_id",
+	container_ids = [booking.container_id for booking in bookings]
+	inspected_containers = set(
+		frappe.db.get_all(
+			"Container Inspection",
+			filters={"container_id": ["in", container_ids], "docstatus": ["!=", 2]},
+			fields=["container_id"],
+			pluck="container_id",
+		)
 	)
+	delivered_containers = set(get_delivered_containers(container_ids))
 
 	count = 0
 	skipped = 0
 	for booking in bookings:
+		if booking.container_id in delivered_containers:
+			skipped += 1
+			continue
+
 		if booking.container_inspection:
 			skipped += 1
 			continue
@@ -221,8 +239,8 @@ def create_bulk_inspections(data):
 
 	if skipped > 0:
 		frappe.msgprint(
-			f"Skipped <b>{skipped}</b> of <b>{len(bookings)}</b> Booking(s), "
-			"they already have an Inspection"
+			f"Skipped <b>{skipped}</b> of <b>{len(bookings)}</b> Booking(s), they already have an Inspection "
+			"or their containers have already been delivered"
 		)
 
 	return count

--- a/icd_tz/icd_tz/doctype/in_yard_container_booking/in_yard_container_booking.js
+++ b/icd_tz/icd_tz/doctype/in_yard_container_booking/in_yard_container_booking.js
@@ -39,7 +39,7 @@ frappe.ui.form.on("In Yard Container Booking", {
 		frm.set_query("container_id", () => {
 			return {
 				filters: {
-					"status": ["!=", "Delivered"],
+					"status": ["not in", ["At Gate Confirmation", "Delivered"]],
 				}
 			};
 		});

--- a/icd_tz/icd_tz/doctype/in_yard_container_booking/in_yard_container_booking.py
+++ b/icd_tz/icd_tz/doctype/in_yard_container_booking/in_yard_container_booking.py
@@ -5,10 +5,19 @@ import frappe
 from frappe.model.document import Document
 from frappe.utils import get_url_to_form, now_datetime, nowdate
 
+from icd_tz.icd_tz.api.utils import (
+	DELIVERED_CONTAINER_STATUSES,
+	validate_delivered_container,
+)
+
 
 class InYardContainerBooking(Document):
 	def before_insert(self):
+		validate_delivered_container(self.container_id, self.container_no)
 		self.posting_datetime = now_datetime()
+
+	def before_cancel(self):
+		validate_delivered_container(self.container_id, self.container_no, action="cancelled")
 
 	def after_insert(self):
 		frappe.db.set_value("Container", self.container_id, "status", "At Booking")
@@ -69,7 +78,7 @@ def create_bulk_bookings(data):
 	validate_cf_agent(data.get("c_and_f_company"), data.get("clearing_agent"))
 
 	filters = {
-		"status": ["!=", "Delivered"],
+		"status": ["not in", DELIVERED_CONTAINER_STATUSES],
 	}
 
 	if data.get("m_bl_no"):
@@ -87,13 +96,15 @@ def create_bulk_bookings(data):
 		msg = f"H BL No: <b>{data.get('h_bl_no')}</b>"
 
 	if len(containers) == 0:
-		frappe.msgprint(f"No Containers found for {msg}")
+		frappe.msgprint(f"No Containers found for {msg} or they have already been delivered")
 		return
 
-	booked_containers = frappe.db.get_all(
-		"In Yard Container Booking",
-		filters={"container_id": ["in", containers], "docstatus": ["!=", 2]},
-		pluck="container_id",
+	booked_containers = set(
+		frappe.db.get_all(
+			"In Yard Container Booking",
+			filters={"container_id": ["in", containers], "docstatus": ["!=", 2]},
+			pluck="container_id",
+		)
 	)
 
 	count = 0

--- a/icd_tz/icd_tz/doctype/service_order/service_order.js
+++ b/icd_tz/icd_tz/doctype/service_order/service_order.js
@@ -19,7 +19,7 @@ frappe.ui.form.on('Service Order', {
 		frm.set_query("container_id", () => {
 			return {
 				filters: {
-					"status": ["!=", "Delivered"],
+					"status": ["not in", ["At Gate Confirmation", "Delivered"]],
 				}
 			};
 		});

--- a/icd_tz/icd_tz/doctype/service_order/service_order.py
+++ b/icd_tz/icd_tz/doctype/service_order/service_order.py
@@ -5,11 +5,17 @@ import frappe
 from frappe.model.document import Document
 
 from icd_tz.icd_tz.api.sales_order import get_container_days_to_be_billed
-from icd_tz.icd_tz.api.utils import validate_cf_agent, validate_draft_doc
+from icd_tz.icd_tz.api.utils import (
+	DELIVERED_CONTAINER_STATUSES,
+	validate_cf_agent,
+	validate_delivered_container,
+	validate_draft_doc,
+)
 
 
 class ServiceOrder(Document):
 	def before_insert(self):
+		validate_delivered_container(self.container_id, self.container_no)
 		self.set_missing_values()
 		self.validate_draft_references()
 		self.get_services()
@@ -31,6 +37,7 @@ class ServiceOrder(Document):
 		self.create_getpass()
 
 	def before_cancel(self):
+		validate_delivered_container(self.container_id, self.container_no, action="cancelled")
 		self.check_for_gate_pass()
 
 	def check_for_gate_pass(self):
@@ -452,7 +459,10 @@ class ServiceOrder(Document):
 def create_bulk_service_orders(data):
 	data = frappe.parse_json(data)
 
-	filters = {}
+	filters = {
+		"status": ["not in", DELIVERED_CONTAINER_STATUSES],
+	}
+
 	if data.get("m_bl_no"):
 		filters["m_bl_no"] = data.get("m_bl_no")
 		filters["has_hbl"] = 0
@@ -469,7 +479,7 @@ def create_bulk_service_orders(data):
 		msg = f"H BL No: <b>{data.get('h_bl_no')}</b>"
 
 	if len(containers) == 0:
-		frappe.msgprint(f"No Containers found for {msg}")
+		frappe.msgprint(f"No Containers found for {msg}, or their containers have already been delivered")
 		return
 
 	count = 0


### PR DESCRIPTION
Bookings, Inspections and Service Orders all push a status onto the Container, so creating or cancelling them after the container has gated out corrupts its state.

Containers on "At Gate Confirmation" or "Delivered" are now left out of the three bulk creation methods and of the container link filters on the Booking and Service Order forms. A guard on before_insert and before_cancel blocks the single record paths, naming the container and its current status.

The two statuses, the guard and the bulk lookup live in api/utils.py as DELIVERED_CONTAINER_STATUSES, validate_delivered_container and get_delivered_containers.