### PR TITLE
feat(container): replace departure_date with gate_out_date

### DIFF
--- a/icd_tz/icd_tz/doctype/container/container.json
+++ b/icd_tz/icd_tz/doctype/container/container.json
@@ -65,7 +65,7 @@
   "column_break_ztec",
   "booking_date",
   "last_inspection_date",
-  "departure_date",
+  "gate_out_date",
   "movement_details_section",
   "original_location",
   "current_location",
@@ -184,13 +184,6 @@
   {
    "fieldname": "column_break_qkrn",
    "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "departure_date",
-   "fieldtype": "Date",
-   "label": "Departure Date",
-   "read_only": 1,
-   "search_index": 1
   },
   {
    "fieldname": "last_inspection_date",
@@ -717,12 +710,19 @@
    "label": "Ship D/C Date",
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "gate_out_date",
+   "fieldtype": "Date",
+   "label": "Gate Out Date",
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-08-01 14:26:58.618264",
+ "modified": "2026-08-04 09:14:16.744506",
  "modified_by": "Administrator",
  "module": "Icd Tz",
  "name": "Container",


### PR DESCRIPTION
departure_date was never written by any code. Replace it with a read only gate_out_date, stamped from the Gate Pass when the container is confirmed out of the ICD, so reports can read the exit date from the Container.