### PR TITLE
feat(gate pass): stamp gate out date on the container

### DIFF
--- a/icd_tz/icd_tz/doctype/gate_pass/gate_pass.py
+++ b/icd_tz/icd_tz/doctype/gate_pass/gate_pass.py
@@ -9,6 +9,7 @@ from frappe.utils import (
 	get_datetime,
 	get_fullname,
 	get_url_to_form,
+	getdate,
 	now_datetime,
 	nowdate,
 	nowtime,
@@ -318,6 +319,9 @@ class GatePass(Document):
 
 		gate_out_datetime = now_datetime()
 		self.db_set("gate_out_date", gate_out_datetime)
+
+		if self.container_id:
+			frappe.db.set_value("Container", self.container_id, "gate_out_date", getdate(gate_out_datetime))
 
 	def update_submitted_info(self):
 		self.submitted_by = get_fullname(frappe.session.user)


### PR DESCRIPTION
set_gate_out_date now writes the date onto the linked Container as well, next to the status update, so one place owns both and they cannot drift.