### PR TITLE
feat(patch): backfill container ship_dc_date from container reception

### DIFF
--- a/icd_tz/patches.txt
+++ b/icd_tz/patches.txt
@@ -6,3 +6,5 @@ icd_tz.patches.create_icd_services
 icd_tz.patches.create_container_states
 icd_tz.patches.update_icd_settings
 icd_tz.patches.migrate_transporters_to_suppliers
+icd_tz.patches.backfill_container_ship_dc_date
+icd_tz.patches.backfill_container_gate_out_date

--- a/icd_tz/patches/backfill_container_ship_dc_date.py
+++ b/icd_tz/patches/backfill_container_ship_dc_date.py
@@ -1,0 +1,22 @@
+import frappe
+
+
+def execute():
+	"""Backfill Container.ship_dc_date from its Container Reception"""
+
+	container = frappe.qb.DocType("Container")
+	reception = frappe.qb.DocType("Container Reception")
+
+	containers = (
+		frappe.qb.from_(container)
+		.inner_join(reception)
+		.on(container.container_reception == reception.name)
+		.select(container.name, reception.ship_dc_date)
+		.where(container.ship_dc_date.isnull())
+		.where(reception.ship_dc_date.isnotnull())
+	).run(as_dict=True)
+
+	for row in containers:
+		frappe.db.set_value("Container", row.name, "ship_dc_date", row.ship_dc_date, update_modified=False)
+
+	print(f"Backfilled Ship D/C Date on {len(containers)} Container(s)")


### PR DESCRIPTION
Older containers only carry the discharge date on their Container Reception, leaving the column empty on the stock and received reports. Copy it across where the container has none, so the patch can be re-run safely.