### PR TITLE
refactor(report): rebuild Current Container Stock on the query builder

### DIFF
--- a/icd_tz/icd_tz/report/current_container_stock/current_container_stock.py
+++ b/icd_tz/icd_tz/report/current_container_stock/current_container_stock.py
@@ -13,34 +13,39 @@ def execute(filters=None):
 def get_columns():
 	return [
 		{"fieldname": "container_no", "label": _("Container No."), "fieldtype": "Data", "width": 120},
-		{"fieldname": "m_bl_no", "label": _("B/L No."), "fieldtype": "Data", "width": 120},
-		{"fieldname": "size", "label": _("Size (FT)"), "fieldtype": "Data", "width": 120},
+		{"fieldname": "m_bl_no", "label": _("B/L No."), "fieldtype": "Data", "width": 130},
+		{"fieldname": "size", "label": _("Size"), "fieldtype": "Data", "width": 70},
+		{
+			"fieldname": "manifest",
+			"label": _("Manifest"),
+			"fieldtype": "Link",
+			"options": "Manifest",
+			"width": 150,
+		},
 		{
 			"fieldname": "consignee",
 			"label": _("Consignee"),
 			"fieldtype": "Link",
 			"options": "Consignee",
-			"width": 150,
+			"width": 160,
 		},
 		{
 			"fieldname": "status",
 			"label": _("Status"),
-			"fieldtype": "Select",
-			"options": ["In Yard", "In Transit", "At Port", "Delivered", "On Hold"],
-			"width": 150,
+			"fieldtype": "Data",
+			"width": 120,
 		},
 		{
 			"fieldname": "port",
 			"label": _("Port Operator"),
-			"fieldtype": "Select",
-			"options": ["DP WORLD", "TEAGTL"],
-			"width": 160,
+			"fieldtype": "Data",
+			"width": 120,
 		},
-		{"fieldname": "ship", "label": _("Shipping Line"), "fieldtype": "Data", "width": 150},
-		{"fieldname": "ship_dc_date", "label": _("Discharge Date"), "fieldtype": "Date", "width": 150},
-		{"fieldname": "received_date", "label": _("Carry In Date"), "fieldtype": "Date", "width": 150},
-		{"fieldname": "cargo_type", "label": _("Cargo Type"), "fieldtype": "Data", "width": 150},
-		{"fieldname": "ship", "label": _("Vessel Name"), "fieldtype": "Data", "width": 150},
+		{"fieldname": "vessel_name", "label": _("Vessel Name"), "fieldtype": "Data", "width": 150},
+		{"fieldname": "shipping_line", "label": _("Shipping Line"), "fieldtype": "Data", "width": 150},
+		{"fieldname": "ship_dc_date", "label": _("Discharge Date"), "fieldtype": "Date", "width": 120},
+		{"fieldname": "received_date", "label": _("Carry In Date"), "fieldtype": "Date", "width": 120},
+		{"fieldname": "cargo_type", "label": _("Cargo Type"), "fieldtype": "Data", "width": 80},
 		{
 			"fieldname": "cargo_description",
 			"label": _("Goods Description"),
@@ -51,54 +56,34 @@ def get_columns():
 
 
 def get_data(filters=None):
-	# Define status groups
-	in_house_statuses = ["In Yard", "At Booking", "At Inspection", "At Payments"]
-	delivered_statuses = ["Delivered"]
+	container = frappe.qb.DocType("Container")
 
-	# Initialize conditions list and parameters
-	conditions = []
-	params = []
+	query = (
+		frappe.qb.from_(container)
+		.select(
+			container.container_no,
+			container.m_bl_no,
+			container.size,
+			container.manifest,
+			container.consignee,
+			container.status,
+			container.cargo_description,
+			container.port_of_destination.as_("port"),
+			container.ship.as_("vessel_name"),
+			container.sline.as_("shipping_line"),
+			container.ship_dc_date,
+			container.received_date,
+			container.cargo_type,
+		)
+		.where(container.has_hbl == 0)
+	)
 
-	# Apply filters based on status_filter
-	if filters and filters.get("status_filter"):
-		status_filter = filters["status_filter"]
-		if status_filter == "In House":
-			conditions.append(f"c.status IN ({', '.join(['%s'] * len(in_house_statuses))})")
-			params.extend(in_house_statuses)
-		elif status_filter == "Delivered":
-			conditions.append(f"c.status IN ({', '.join(['%s'] * len(delivered_statuses))})")
-			params.extend(delivered_statuses)
+	status_filter = filters.get("status_filter") if filters else None
+
+	# a container that is not Delivered is still in house
+	if status_filter == "Delivered":
+		query = query.where(container.status == "Delivered")
 	else:
-		# Default condition to exclude 'Delivered' status
-		conditions.append(f"c.status NOT IN ({', '.join(['%s'] * len(delivered_statuses))})")
-		params.extend(delivered_statuses)
+		query = query.where(container.status != "Delivered")
 
-	# Combine conditions into a single string
-	where_clause = " AND ".join(conditions) if conditions else "1=1"
-
-	sql_query = f"""
-    SELECT
-        c.container_no,
-        c.m_bl_no,
-        c.size,
-        c.consignee,
-        c.status,
-        c.container_reception,
-        cr.port,
-        cr.ship,
-        cr.name,
-        cr.ship_dc_date,
-        cr.received_date,
-        cr.cargo_type,
-        c.cargo_description,
-        c.ship
-    FROM
-        `tabContainer` AS c
-    LEFT JOIN
-        `tabContainer Reception` AS cr ON c.container_reception = cr.name
-    LEFT JOIN
-		`tabGate Pass` As gp ON c.name = gp.container_id
-    WHERE {where_clause}
-    """
-
-	return frappe.db.sql(sql_query, params, as_dict=True)
+	return query.run(as_dict=True)


### PR DESCRIPTION
Drop the Gate Pass join, which selected nothing and duplicated a row per gate pass, and read every column from the Container. Filter on has_hbl = 0 so loose consignments are left to the Loose Cargo Tracking report.

Fix a where clause that concatenated the has_hbl condition without an AND, and separate Vessel Name from Shipping Line, which shared one fieldname and so rendered the same value.