### PR TITLE
refactor(report): rebuild Received Containers on the query builder

### DIFF
--- a/icd_tz/icd_tz/report/received_containers/received_containers.py
+++ b/icd_tz/icd_tz/report/received_containers/received_containers.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe import _
+from frappe.query_builder import Order
 
 
 def execute(filters=None):
@@ -23,7 +24,7 @@ def get_columns():
 	"""Define columns for the report"""
 	return [
 		{"fieldname": "bl_no", "label": _("M B/L No."), "fieldtype": "Data", "width": 120},
-		{"fieldname": "arrival_date", "label": _("Discharge Date"), "fieldtype": "Date", "width": 100},
+		{"fieldname": "ship_dc_date", "label": _("Discharge Date"), "fieldtype": "Date", "width": 100},
 		{"fieldname": "port_of_destination", "label": _("Port Operator"), "fieldtype": "Data", "width": 120},
 		{"fieldname": "cargo_type", "label": _("Cargo Type"), "fieldtype": "Data", "width": 100},
 		{"fieldname": "container_no", "label": _("Container No."), "fieldtype": "Data", "width": 120},
@@ -41,7 +42,7 @@ def get_columns():
 	]
 
 
-def get_data(filters):
+def get_data(filters=None):
 	"""
 	Fetch and return report data
 	Args:
@@ -49,40 +50,39 @@ def get_data(filters):
 	Returns:
 	    list: List of dictionaries containing report data
 	"""
-	conditions = get_conditions(filters)
+	filters = filters or {}
 
-	query = f"""
-        SELECT
-            c.arrival_date,
-            c.port_of_destination,
-            c.container_no,
-            c.m_bl_no AS bl_no,
-            c.size,
-            c.consignee AS consignee_name,
-            c.cargo_description AS description_of_goods,
-            c.sline,
-            c.cargo_type,
-            c.ship,
-            cr.transporter
-        FROM
-            `tabContainer` c
-        LEFT JOIN `tabContainer Reception` cr ON c.container_reception = cr.name
-        WHERE
-            1=1 {conditions}
-        ORDER BY
-            c.posting_date DESC
-    """
+	container = frappe.qb.DocType("Container")
+	reception = frappe.qb.DocType("Container Reception")
 
-	data = frappe.db.sql(query, filters, as_dict=1)
-	return data
+	query = (
+		frappe.qb.from_(container)
+		.inner_join(reception)
+		.on(container.container_reception == reception.name)
+		.select(
+			container.m_bl_no.as_("bl_no"),
+			container.ship_dc_date,
+			container.port_of_destination,
+			container.cargo_type,
+			container.container_no,
+			container.size,
+			container.consignee.as_("consignee_name"),
+			container.cargo_description.as_("description_of_goods"),
+			container.sline,
+			container.ship,
+			reception.transporter,
+		)
+		.where(container.has_hbl == 0)
+		.orderby(container.posting_date, order=Order.desc)
+	)
 
-
-def get_conditions(filters):
-	conditions = []
 	if filters.get("from_date"):
-		conditions.append("c.posting_date >= %(from_date)s")
+		query = query.where(container.posting_date >= filters.get("from_date"))
+
 	if filters.get("to_date"):
-		conditions.append("c.posting_date <= %(to_date)s")
+		query = query.where(container.posting_date <= filters.get("to_date"))
+
 	if filters.get("bl_no"):
-		conditions.append("c.m_bl_no = %(bl_no)s")
-	return " AND " + " AND ".join(conditions) if conditions else ""
+		query = query.where(container.m_bl_no == filters.get("bl_no"))
+
+	return query.run(as_dict=True)


### PR DESCRIPTION
Read every column from the Container and keep an inner join to the Container Reception only for the transporter, which is not held anywhere else. Filter on has_hbl = 0 to leave loose consignments out.

Replace the hand built condition string with where clauses on the builder and default the filters argument, so the report no longer breaks when it is called without filters.