### PR TITLE
fix(report): make Gate Out Pass work without a Gate Pass workflow

### DIFF
--- a/icd_tz/icd_tz/report/gate_out_pass/gate_out_pass.py
+++ b/icd_tz/icd_tz/report/gate_out_pass/gate_out_pass.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe import _
+from frappe.query_builder import Order
 
 
 def execute(filters=None):
@@ -27,53 +28,56 @@ def get_columns():
 			"options": "Consignee",
 			"width": 150,
 		},
-		{"fieldname": "freight_indicator", "label": _("Status"), "fieldtype": "Data", "width": 150},
+		{"fieldname": "container_status", "label": _("Status"), "fieldtype": "Data", "width": 150},
 		{"fieldname": "place_of_destination", "label": _("Destination"), "fieldtype": "Data", "width": 150},
 		{"fieldname": "ship_dc_date", "label": _("Ship D/C Date"), "fieldtype": "Date", "width": 150},
-		{"fieldname": "arrival_date", "label": _("Date In"), "fieldtype": "Date", "width": 150},
+		{"fieldname": "received_date", "label": _("Date In"), "fieldtype": "Date", "width": 150},
 		{"fieldname": "gate_out_date", "label": _("Gate Out Date"), "fieldtype": "Datetime", "width": 150},
 	]
 
 
 def get_data(filters=None):
-	conditions = get_conditions(filters)
-	query = f"""
-  SELECT
-    gp.container_no,
-    gp.m_bl_no,
-    gp.h_bl_no,
-    gp.size,
-    gp.consignee,
-    gp.sline,
-    gp.c_and_f_company,
-    gp.vessel_name,
-    gp.voyage_no,
-    c.freight_indicator,
-    c.place_of_destination,
-    gp.ship_dc_date,
-    c.arrival_date,
-    gp.gate_out_date AS gate_out_date
-  FROM
-    `tabGate Pass` AS gp
-  JOIN
-    `tabContainer` AS c ON gp.container_id = c.name
-  WHERE
-    gp.docstatus = 1
-    AND gp.workflow_state = 'Gate Out Confirmed'
-    {conditions}
-  """
-	return frappe.db.sql(query, filters, as_dict=True)
-
-
-def get_conditions(filters):
 	filters = filters or {}
-	conditions = []
+
+	gate_pass = frappe.qb.DocType("Gate Pass")
+	# Destination is the only column that is not kept on the Gate Pass
+	container = frappe.qb.DocType("Container")
+
+	query = (
+		frappe.qb.from_(gate_pass)
+		.left_join(container)
+		.on(gate_pass.container_id == container.name)
+		.select(
+			gate_pass.container_no,
+			gate_pass.m_bl_no,
+			gate_pass.h_bl_no,
+			gate_pass.size,
+			gate_pass.consignee,
+			gate_pass.sline,
+			gate_pass.c_and_f_company,
+			gate_pass.vessel_name,
+			gate_pass.voyage_no,
+			gate_pass.container_status,
+			gate_pass.ship_dc_date,
+			gate_pass.received_date,
+			container.place_of_destination,
+			gate_pass.gate_out_date,
+		)
+		.where(gate_pass.docstatus == 1)
+		.where(gate_pass.gate_out_date.isnotnull())
+		.orderby(gate_pass.gate_out_date, order=Order.desc)
+	)
+
 	if filters.get("m_bl_no"):
-		conditions.append("gp.m_bl_no = %(m_bl_no)s")
+		query = query.where(gate_pass.m_bl_no == filters.get("m_bl_no"))
+
 	if filters.get("h_bl_no"):
-		conditions.append("gp.h_bl_no = %(h_bl_no)s")
+		query = query.where(gate_pass.h_bl_no == filters.get("h_bl_no"))
+
 	if filters.get("from_date"):
-		conditions.append("DATE(gp.gate_out_date) >= %(from_date)s")
+		query = query.where(gate_pass.gate_out_date >= filters.get("from_date"))
+
 	if filters.get("to_date"):
-		conditions.append("DATE(gp.gate_out_date) <= %(to_date)s")
-	return " AND " + " AND ".join(conditions) if conditions else ""
+		query = query.where(gate_pass.gate_out_date <= filters.get("to_date"))
+
+	return query.run(as_dict=True)


### PR DESCRIPTION
Filtering on workflow_state broke the report on sites with no workflow installed. Require gate_out_date instead, which is only stamped once the pass is used at the gate and carries the same meaning without depending on the workflow being present.

Read the container status and received date from the Gate Pass itself and rebuild the query on the query builder.