### PR TITLE
fix(report): rebuild Revenue Summary per invoice line item

### DIFF
--- a/icd_tz/icd_tz/report/revenue_summary/revenue_summary.js
+++ b/icd_tz/icd_tz/report/revenue_summary/revenue_summary.js
@@ -5,23 +5,15 @@
 frappe.query_reports["Revenue Summary"] = {
     "filters": [
         {
-            "fieldname": "currency",
-            "label": "Currency",
-            "fieldtype": "Link",
-            "options": "Currency",
-        },
-        {
             "fieldname": "from_date",
             "label": "From Date",
             "fieldtype": "Date",
-
             "reqd": 1
         },
         {
             "fieldname": "to_date",
             "label": "To Date",
             "fieldtype": "Date",
-
             "reqd": 1
         },
 		// {
@@ -36,6 +28,12 @@ frappe.query_reports["Revenue Summary"] = {
             "fieldname": "m_bl_no",
             "label": "M B/L No",
             "fieldtype": "Data"
+        },
+        {
+            "fieldname": "currency",
+            "label": "Currency",
+            "fieldtype": "Link",
+            "options": "Currency",
         }
     ],
 

--- a/icd_tz/icd_tz/report/revenue_summary/revenue_summary.py
+++ b/icd_tz/icd_tz/report/revenue_summary/revenue_summary.py
@@ -3,7 +3,19 @@
 
 import frappe
 from frappe import _
+from frappe.query_builder import Order
 from frappe.utils import flt
+
+
+def execute(filters=None):
+	"""Main execution function for the report."""
+	filters = filters or {}
+
+	columns = get_columns(filters)
+	data = get_data(filters)
+	report_summary = get_report_summary(data, filters)
+
+	return columns, data, None, None, report_summary
 
 
 def get_columns(filters):
@@ -16,158 +28,170 @@ def get_columns(filters):
 			"options": "Sales Invoice",
 			"width": 130,
 		},
+		{"fieldname": "posting_date", "label": _("Date"), "fieldtype": "Date", "width": 100},
 		{"fieldname": "c_and_f_company", "label": _("C/Agent Company"), "fieldtype": "Data", "width": 150},
 		{"fieldname": "clearing_agent", "label": _("C/Agent Name"), "fieldtype": "Data", "width": 150},
 		{"fieldname": "vessel_name", "label": _("Vessel Name"), "fieldtype": "Data", "width": 150},
-		{"fieldname": "d_do_no", "label": _("D/DO NO"), "fieldtype": "Data", "width": 120},
-		{"fieldname": "container_size", "label": _("Size"), "fieldtype": "Data", "width": 100},
-		{"fieldname": "containers", "label": _("Containers"), "fieldtype": "Int", "width": 50},
+		{"fieldname": "container_no", "label": _("Container No"), "fieldtype": "Data", "width": 130},
+		{"fieldname": "container_size", "label": _("Size"), "fieldtype": "Data", "width": 80},
+		{"fieldname": "item_code", "label": _("Service"), "fieldtype": "Data", "width": 200},
 	]
 
 	currency = filters.get("currency")
-	if not currency:
-		base_columns.extend(
-			[
-				{
-					"fieldname": "amount_tzs",
-					"label": _("Amount (TZS)"),
-					"fieldtype": "Float",
-					"width": 120,
-					"precision": 2,
-				},
-				{
-					"fieldname": "amount_usd",
-					"label": _("Amount (USD)"),
-					"fieldtype": "Float",
-					"width": 120,
-					"precision": 2,
-				},
-				{"fieldname": "vat", "label": _("VAT"), "fieldtype": "Float", "width": 120, "precision": 2},
-			]
-		)
-	elif currency == "USD":
+
+	if not currency or currency == "TZS":
 		base_columns.append(
-			{
-				"fieldname": "amount_usd",
-				"label": _("Amount (USD)"),
-				"fieldtype": "Float",
-				"width": 120,
-				"precision": 2,
-			}
+			{"fieldname": "amount_tzs", "label": _("Amount (TZS)"), "fieldtype": "Float", "width": 130}
 		)
-	else:
+
+	if not currency or currency == "USD":
 		base_columns.append(
-			{
-				"fieldname": "amount_tzs",
-				"label": _("Amount (TZS)"),
-				"fieldtype": "Float",
-				"width": 120,
-				"precision": 2,
-			}
+			{"fieldname": "amount_usd", "label": _("Amount (USD)"), "fieldtype": "Float", "width": 130}
 		)
+
+	base_columns.append({"fieldname": "vat", "label": _("VAT (TZS)"), "fieldtype": "Float", "width": 130})
 
 	return base_columns
 
 
-def get_service_order_details(service_order):
-	"""Retrieve service order details."""
-	if not service_order:
-		return {"vessel_name": "", "container_size": "", "c_and_f_company": "", "clearing_agent": ""}
-
-	try:
-		service_order_doc = frappe.get_doc("Service Order", service_order)
-		return {
-			"vessel_name": service_order_doc.vessel_name or "",
-			"container_size": service_order_doc.container_size or "",
-			"c_and_f_company": service_order_doc.c_and_f_company or "",
-			"clearing_agent": service_order_doc.clearing_agent or "",
-		}
-	except Exception:
-		frappe.log_error(f"Error fetching Service Order details for {service_order}")
-		return {"vessel_name": "", "container_size": "", "c_and_f_company": "", "clearing_agent": ""}
-
-
-def format_currency_amount(amount, currency):
-	"""Format currency with proper prefix."""
-	if amount == 0:
-		return f"{currency} 0.00"
-	return f"{currency} {flt(amount, 2):,.2f}"
-
-
 def get_data(filters):
-	"""Fetch and process report data."""
-	conditions = []
+	"""One row per Sales Invoice Item, priced in both the invoice and the company currency"""
+	invoice = frappe.qb.DocType("Sales Invoice")
+	invoice_item = frappe.qb.DocType("Sales Invoice Item")
+
+	query = (
+		frappe.qb.from_(invoice)
+		.inner_join(invoice_item)
+		.on(invoice_item.parent == invoice.name)
+		.select(
+			invoice.name.as_("receipt_no"),
+			invoice.posting_date,
+			invoice.currency,
+			invoice.c_and_f_company,
+			invoice.base_net_total,
+			invoice.base_total_taxes_and_charges,
+			invoice_item.item_code,
+			invoice_item.container_id,
+			invoice_item.container_no,
+			invoice_item.amount,
+			invoice_item.base_amount,
+			invoice_item.base_net_amount,
+		)
+		.where(invoice.docstatus == 1)
+		.orderby(invoice.posting_date, order=Order.desc)
+	)
+
 	if filters.get("from_date"):
-		conditions.append("si.posting_date >= %(from_date)s")
+		query = query.where(invoice.posting_date >= filters.get("from_date"))
+
 	if filters.get("to_date"):
-		conditions.append("si.posting_date <= %(to_date)s")
+		query = query.where(invoice.posting_date <= filters.get("to_date"))
+
 	if filters.get("m_bl_no"):
-		conditions.append("si.m_bl_no = %(m_bl_no)s")
+		query = query.where(invoice.m_bl_no == filters.get("m_bl_no"))
 
-	currency_filter = ""
 	if filters.get("currency"):
-		currency_filter = "AND si.currency = %(currency)s"
+		query = query.where(invoice.currency == filters.get("currency"))
 
-	conditions = " AND ".join(conditions) if conditions else "1=1"
+	rows = query.run(as_dict=True)
 
-	query = f"""
-        SELECT
-            si.posting_date AS date,
-            #si.name AS receipt_no,
-            si.service_order,
-            si.currency,
-            '' AS d_do_no,
-            (SELECT COUNT(DISTINCT item.container_no)
-             FROM `tabSales Invoice Item` item
-             WHERE item.parent = si.name) AS containers,
-            si.currency,
-            CASE
-                WHEN si.currency = 'TZS' THEN si.grand_total
-                ELSE 0
-            END AS raw_amount_tzs,
-            CASE
-                WHEN si.currency = 'USD' THEN si.grand_total
-                ELSE 0
-            END AS raw_amount_usd,
-            si.total_taxes_and_charges AS raw_vat
-        FROM `tabSales Invoice` si
-        WHERE si.docstatus = 1 {currency_filter}
-        AND {conditions}
-        ORDER BY si.posting_date DESC
-    """
+	container_ids = [row.container_id for row in rows if row.container_id]
+	containers = get_container_details(container_ids)
+	clearing_agents = get_clearing_agents(container_ids)
 
-	data = frappe.db.sql(query, filters, as_dict=1)
+	for row in rows:
+		container = containers.get(row.container_id) or {}
+		row.vessel_name = container.get("ship")
+		row.container_size = container.get("size")
+		row.clearing_agent = clearing_agents.get(row.container_id)
 
-	# Process the data and format currencies
-	processed_data = []
-	for row in data:
-		processed_row = row.copy()
+		# base_ fields are always in company currency, the invoice currency keeps its own column
+		row.amount_tzs = flt(row.base_amount)
+		row.amount_usd = flt(row.amount) if row.currency == "USD" else 0
 
-		# Get service order details
-		if row.service_order:
-			processed_row.update(get_service_order_details(row.service_order))
+		# tax is only kept on the invoice, share it across its items so the column still adds up
+		row.vat = 0
+		if row.base_net_total:
+			row.vat = (
+				flt(row.base_total_taxes_and_charges) * flt(row.base_net_amount) / flt(row.base_net_total)
+			)
 
-		# Format currency amounts with proper prefix
-		if row.currency == "USD":
-			processed_row["amount_tzs"] = "TZS 0.00"
-			processed_row["amount_usd"] = format_currency_amount(row.raw_amount_usd, "USD")
-			processed_row["vat"] = format_currency_amount(row.raw_vat, "USD")
-		else:  # TZS
-			processed_row["amount_tzs"] = format_currency_amount(row.raw_amount_tzs, "TZS")
-			processed_row["amount_usd"] = "USD 0.00"
-			processed_row["vat"] = format_currency_amount(row.raw_vat, "TZS")
-
-		processed_data.append(processed_row)
-
-	return processed_data
+	return rows
 
 
-def execute(filters=None):
-	"""Main execution function for the report."""
-	if not filters:
-		filters = {}
+def get_container_details(container_ids):
+	"""Vessel and size of every container on the report, keyed by container id"""
+	if len(container_ids) == 0:
+		return {}
 
-	columns = get_columns(filters)
-	data = get_data(filters)
+	containers = frappe.db.get_all(
+		"Container", filters={"name": ["in", container_ids]}, fields=["name", "ship", "size"]
+	)
 
-	return columns, data
+	return {container.name: container for container in containers}
+
+
+def get_clearing_agents(container_ids):
+	"""Clearing agent of every container on the report, taken from its Service Order"""
+	if len(container_ids) == 0:
+		return {}
+
+	service_orders = frappe.db.get_all(
+		"Service Order",
+		filters={"container_id": ["in", container_ids], "docstatus": ["!=", 2]},
+		fields=["container_id", "clearing_agent"],
+	)
+
+	return {order.container_id: order.clearing_agent for order in service_orders}
+
+
+def get_report_summary(data, filters):
+	"""Totals of the invoice lines shown on the report"""
+	total_tzs = sum(flt(row.get("amount_tzs")) for row in data)
+	total_usd = sum(flt(row.get("amount_usd")) for row in data)
+	total_vat = sum(flt(row.get("vat")) for row in data)
+
+	summary = [
+		{"label": _("Invoices"), "value": len({row.get("receipt_no") for row in data}), "datatype": "Int"},
+		{
+			"label": _("Containers"),
+			"value": len({row.get("container_no") for row in data if row.get("container_no")}),
+			"datatype": "Int",
+		},
+	]
+
+	currency = filters.get("currency")
+
+	if not currency or currency == "TZS":
+		summary.append(
+			{
+				"label": _("Amount (TZS)"),
+				"value": total_tzs,
+				"datatype": "Currency",
+				"options": "TZS",
+				"indicator": "Green",
+			}
+		)
+
+	if not currency or currency == "USD":
+		summary.append(
+			{
+				"label": _("Amount (USD)"),
+				"value": total_usd,
+				"datatype": "Currency",
+				"options": "USD",
+				"indicator": "Blue",
+			}
+		)
+
+	summary.append(
+		{
+			"label": _("VAT (TZS)"),
+			"value": total_vat,
+			"datatype": "Currency",
+			"options": "TZS",
+			"indicator": "Orange",
+		}
+	)
+
+	return summary


### PR DESCRIPTION
The report selected si.service_order, which does not exist on the Sales Invoice, so it failed on every run, and Receipt No was commented out with a # inside the SQL and never returned.

Report one row per Sales Invoice Item with its container, taking the clearing agent from the Service Order and the vessel and size from the Container, both matched on the item's container id. The C/Agent company comes from the invoice itself, so get_service_order_details and the document load it did per row are removed.

Amounts are numbers rather than preformatted strings, with base_ fields used for the company currency, and each invoice's tax is shared across its items so the VAT column reconciles. A summary of invoices, containers, amounts and tax is shown on top of the report.