### PR TITLE
feat(container movement order): let the discharge date be corrected

### DIFF
--- a/icd_tz/icd_tz/doctype/container_movement_order/container_movement_order.json
+++ b/icd_tz/icd_tz/doctype/container_movement_order/container_movement_order.json
@@ -309,14 +309,12 @@
    "label": "Select Container"
   },
   {
-   "description": "Port discharge date",
+   "depends_on": "eval: !doc.__islocal",
    "fieldname": "ship_dc_date",
    "fieldtype": "Date",
    "in_preview": 1,
    "in_standard_filter": 1,
    "label": "Ship D/C Date",
-   "read_only": 1,
-   "reqd": 1,
    "search_index": 1
   },
   {


### PR DESCRIPTION
Show ship_dc_date only once the document has been saved, since it is filled from TANeSW at that point, and drop read only and mandatory so a user can supply or correct the date when the lookup finds nothing.