### PR TITLE
feat(master bl): add an Update Values button to the row

### DIFF
--- a/icd_tz/icd_tz/doctype/master_bl/master_bl.json
+++ b/icd_tz/icd_tz/doctype/master_bl/master_bl.json
@@ -8,6 +8,7 @@
  "engine": "InnoDB",
  "field_order": [
   "m_bl_no",
+  "update_values",
   "cargo_classification",
   "bl_type",
   "port_of_loading",
@@ -59,6 +60,13 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "M B/L No"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "update_values",
+   "fieldtype": "Button",
+   "label": "Update Values",
+   "permlevel": 1
   },
   {
    "fieldname": "cargo_classification",


### PR DESCRIPTION
The button is allowed on submit, so the classification and destination of a row can still be corrected once the Manifest has been submitted, and sits at permlevel 1 so only users with that level can use it.