### PR TITLE
fix(container reception): do not allow cancelling after the container left

### DIFF
--- a/icd_tz/icd_tz/doctype/container_reception/container_reception.py
+++ b/icd_tz/icd_tz/doctype/container_reception/container_reception.py
@@ -8,6 +8,7 @@ from frappe.utils import get_link_to_form, getdate, nowdate, time_diff_in_hours
 from frappe.utils.background_jobs import enqueue
 
 from icd_tz.icd_tz.api.edi_codeco import generate_codeco_gate_in
+from icd_tz.icd_tz.api.utils import validate_delivered_containers
 from icd_tz.icd_tz.doctype.container.container import daily_update_date_container_stay
 
 cr = DocType("Container Reception")
@@ -92,7 +93,15 @@ class ContainerReception(Document):
 		self.update_cmo_status("Received")
 
 	def before_cancel(self):
+		self.validate_delivered_containers()
 		self.cancel_linked_docs()
+
+	def validate_delivered_containers(self):
+		"""Cancelling cascades to the linked documents, a container that left must keep them"""
+
+		validate_delivered_containers(
+			frappe.db.get_all("Container", {"container_reception": self.name}, pluck="name")
+		)
 
 	def on_cancel(self):
 		self.update_cmo_status()


### PR DESCRIPTION
Cancelling a reception cascades through cancel_linked_docs, which cancels the Service Orders, Inspections and bookings of its container and unwinds the container itself. On a container that has already gone out that wipes the record of cargo which is no longer in the yard.

Check the containers created by the reception before the cascade starts.