### PR TITLE
feat(patch): add the Manifest as an accounting dimension

### DIFF
--- a/icd_tz/patches.txt
+++ b/icd_tz/patches.txt
@@ -8,3 +8,4 @@ icd_tz.patches.update_icd_settings
 icd_tz.patches.migrate_transporters_to_suppliers
 icd_tz.patches.backfill_container_ship_dc_date
 icd_tz.patches.backfill_container_gate_out_date
+icd_tz.patches.create_manifest_accounting_dimension

--- a/icd_tz/patches/create_manifest_accounting_dimension.py
+++ b/icd_tz/patches/create_manifest_accounting_dimension.py
@@ -1,0 +1,21 @@
+import frappe
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+	make_dimension_in_accounting_doctypes,
+)
+
+
+def execute():
+	"""Add the Manifest as an accounting dimension so ICD revenue can be reported per manifest"""
+
+	if frappe.db.exists("Accounting Dimension", {"document_type": "Manifest"}):
+		return
+
+	dimension = frappe.new_doc("Accounting Dimension")
+	dimension.document_type = "Manifest"
+	dimension.flags.ignore_permissions = True
+	dimension.insert()
+
+	# on_update only queues the field creation, run it here so the fields exist once the patch ends
+	make_dimension_in_accounting_doctypes(doc=dimension)
+
+	print(f"Added the Manifest accounting dimension, field: {dimension.fieldname}")


### PR DESCRIPTION
Create the Accounting Dimension for the Manifest so ICD revenue can be reported per manifest, which adds a manifest link field to the accounting doctypes including Sales Order, Sales Invoice, their item tables and the GL Entry.

Creating the dimension only queues the field creation, so the patch runs make_dimension_in_accounting_doctypes itself and the fields exist by the time the migrate finishes. It skips when the dimension is already there, so it is safe to re-run.