### PR TITLE
fix(manifest): drop f-string quoting that needs Python 3.12

### DIFF
--- a/icd_tz/icd_tz/doctype/manifest/manifest.py
+++ b/icd_tz/icd_tz/doctype/manifest/manifest.py
@@ -362,7 +362,7 @@ def update_master_bl_values(row_id, cargo_classification, place_of_destination):
 	"""Set the classification and destination of a Master BL row of an already submitted Manifest"""
 
 	if cargo_classification not in ["IM", "TR"]:
-		frappe.throw(f"Cargo Classification must be one of: <b>{', '.join(["IM", "TR"])}</b>")
+		frappe.throw("Cargo Classification must be one of: <b>IM, TR</b>")
 
 	if not place_of_destination:
 		frappe.throw("Please select a Country to set the Place of Destination")


### PR DESCRIPTION
The message reused double quotes inside its own expression, which only parses from Python 3.12, so installing the app on the 3.10 runner failed with an unmatched bracket error. The text is static, so the f-string is not needed at all.