### PR TITLE
fix(waiver request): require remarks when a request is rejected

### DIFF
--- a/icd_tz/icd_tz/doctype/waiver_request/waiver_request.json
+++ b/icd_tz/icd_tz/doctype/waiver_request/waiver_request.json
@@ -243,7 +243,8 @@
    "depends_on": "eval:doc.decision == \"Rejected\"",
    "fieldname": "rejection_remarks",
    "fieldtype": "Small Text",
-   "label": "Rejection Remarks"
+   "label": "Remarks",
+   "mandatory_depends_on": "eval:doc.decision == \"Rejected\""
   },
   {
    "fieldname": "section_break_users",
@@ -287,7 +288,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-07-31 00:00:00.000000",
+ "modified": "2026-08-05 18:03:25.311648",
  "modified_by": "Administrator",
  "module": "Icd Tz",
  "name": "Waiver Request",
@@ -310,6 +311,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
- Add mandatory_depends_on to rejection_remarks so a rejected request cannot be submitted without a reason
- Rename the label from "Rejection Remarks" to "Remarks", the field is already shown only for rejections